### PR TITLE
Rename curent_ship references to current_ship

### DIFF
--- a/Main_scane/Commander/ship.gd
+++ b/Main_scane/Commander/ship.gd
@@ -137,7 +137,7 @@ func _on_flagman_toggled(on : bool) -> void:
 	BattlegroupData.emit_signal("battlegroup_change")
 
 func _on_option_pressed() -> void:
-	BattlegroupData.curent_ship = _index
+        BattlegroupData.current_ship = _index
 	BattlegroupData.change_on_option()
 
 # ───────────────────────────────────────────

--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -23,9 +23,9 @@ extends PanelContainer
 var _src: Dictionary    
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
-		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
-		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
+        if _src.size() != 0 and BattlegroupData.current_ship != -1:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
 			var sum = {
 				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
 				"escort": int(ship["support_slots"]["escorts"]),
@@ -34,7 +34,7 @@ func _process(delta: float) -> void:
 				"system": int(ship["support_slots"]["systems"]),
 				"wing": int(ship["support_slots"]["wings"])
 			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
+                        for x in BattlegroupData.ships[BattlegroupData.current_ship]["option"]:
 				sum["auxiliary"] += int(x["modification"]["auxiliary"])
 				sum["escort"] += int(x["modification"]["escort"])
 				sum["primary"] += int(x["modification"]["primary"])
@@ -99,8 +99,8 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].append(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
 
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].erase(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)

--- a/Main_scane/Option_list/option_list.gd
+++ b/Main_scane/Option_list/option_list.gd
@@ -74,7 +74,7 @@ func _apply_ship_filter() -> void:
 	for d in _slot_info.values():
 		d.node.visible = false
 
-	var idx := int(BattlegroupData.curent_ship)
+        var idx := int(BattlegroupData.current_ship)
 	if idx < 0 or idx >= BattlegroupData.ships.size():
 		return                                     # корабль не выбран
 

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -23,9 +23,9 @@ extends PanelContainer
 var _src: Dictionary    
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
-		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
-		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
+        if _src.size() != 0 and BattlegroupData.current_ship != -1:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
 			var sum = {
 				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
 				"escort": int(ship["support_slots"]["escorts"]),
@@ -34,7 +34,7 @@ func _process(delta: float) -> void:
 				"system": int(ship["support_slots"]["systems"]),
 				"wing": int(ship["support_slots"]["wings"])
 			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
+                        for x in BattlegroupData.ships[BattlegroupData.current_ship]["option"]:
 				sum["auxiliary"] += int(x["modification"]["auxiliary"])
 				sum["escort"] += int(x["modification"]["escort"])
 				sum["primary"] += int(x["modification"]["primary"])
@@ -91,8 +91,8 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].append(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
 
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].erase(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -10,9 +10,9 @@ extends PanelContainer
 var _src: Dictionary    
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
-		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
-		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
+        if _src.size() != 0 and BattlegroupData.current_ship != -1:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
 			var sum = {
 				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
 				"escort": int(ship["support_slots"]["escorts"]),
@@ -21,7 +21,7 @@ func _process(delta: float) -> void:
 				"system": int(ship["support_slots"]["systems"]),
 				"wing": int(ship["support_slots"]["wings"])
 			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
+                        for x in BattlegroupData.ships[BattlegroupData.current_ship]["option"]:
 				sum["auxiliary"] += int(x["modification"]["auxiliary"])
 				sum["escort"] += int(x["modification"]["escort"])
 				sum["primary"] += int(x["modification"]["primary"])
@@ -72,8 +72,8 @@ func populate(weapon):
 
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].append(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
 
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.curent_ship]["option"].erase(_src)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)

--- a/battlegroup_data.gd
+++ b/battlegroup_data.gd
@@ -21,7 +21,7 @@ var class_counts := {
 	ShipClass.BATTLESHIP: 0,
 }
 
-var curent_ship = -1
+var current_ship = -1
 
 var ships: Array = []     # хранит сами словари-корпуса
 


### PR DESCRIPTION
## Summary
- Rename typo `curent_ship` to `current_ship` in battlegroup data
- Update Commander and Option list scripts to use `current_ship`

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689af12b600c8320b6df7d0c071766e7