### PR TITLE
refactor: centralize slot summation

### DIFF
--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const SlotUtils = preload("res://slot_utils.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -26,21 +28,7 @@ func _process(delta: float) -> void:
 	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
 		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
 		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
-			var sum = {
-				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
-				"escort": int(ship["support_slots"]["escorts"]),
-				"primary": int(ship["weapon_slots"]["primaries"]),
-				"superheavy": int(ship["weapon_slots"]["superheavy"]),
-				"system": int(ship["support_slots"]["systems"]),
-				"wing": int(ship["support_slots"]["wings"])
-			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
-				sum["auxiliary"] += int(x["modification"]["auxiliary"])
-				sum["escort"] += int(x["modification"]["escort"])
-				sum["primary"] += int(x["modification"]["primary"])
-				sum["superheavy"] += int(x["modification"]["superheavy"])
-				sum["system"] += int(x["modification"]["system"])
-				sum["wing"] += int(x["modification"]["wing"])
+			var sum = SlotUtils.get_slot_sums(ship)
 			if _src["type"] == 0.0 and sum["escort"] <= 0:
 				_add.hide()
 			elif _src["type"] == 1.0 and sum["wing"] <= 0:

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const SlotUtils = preload("res://slot_utils.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -26,21 +28,7 @@ func _process(delta: float) -> void:
 	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
 		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
 		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
-			var sum = {
-				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
-				"escort": int(ship["support_slots"]["escorts"]),
-				"primary": int(ship["weapon_slots"]["primaries"]),
-				"superheavy": int(ship["weapon_slots"]["superheavy"]),
-				"system": int(ship["support_slots"]["systems"]),
-				"wing": int(ship["support_slots"]["wings"])
-			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
-				sum["auxiliary"] += int(x["modification"]["auxiliary"])
-				sum["escort"] += int(x["modification"]["escort"])
-				sum["primary"] += int(x["modification"]["primary"])
-				sum["superheavy"] += int(x["modification"]["superheavy"])
-				sum["system"] += int(x["modification"]["system"])
-				sum["wing"] += int(x["modification"]["wing"])
+			var sum = SlotUtils.get_slot_sums(ship)
 			if sum["system"] <= 0:
 				_add.hide()
 			if _src in ship["option"]:

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const SlotUtils = preload("res://slot_utils.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -7,27 +9,13 @@ extends PanelContainer
 @onready var _discription: RichTextLabel = $VBoxContainer/Discription/Discription
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _remove: MarginContainer = $VBoxContainer/Button2
-var _src: Dictionary    
+var _src: Dictionary
 
 func _process(delta: float) -> void:
 	if _src.size() != 0 and BattlegroupData.curent_ship != -1:
 		var ship = BattlegroupData.ships[BattlegroupData.curent_ship]
 		if BattlegroupData.ships[BattlegroupData.curent_ship]["option"].size() != 0:
-			var sum = {
-				"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
-				"escort": int(ship["support_slots"]["escorts"]),
-				"primary": int(ship["weapon_slots"]["primaries"]),
-				"superheavy": int(ship["weapon_slots"]["superheavy"]),
-				"system": int(ship["support_slots"]["systems"]),
-				"wing": int(ship["support_slots"]["wings"])
-			}
-			for x in BattlegroupData.ships[BattlegroupData.curent_ship]["option"]:
-				sum["auxiliary"] += int(x["modification"]["auxiliary"])
-				sum["escort"] += int(x["modification"]["escort"])
-				sum["primary"] += int(x["modification"]["primary"])
-				sum["superheavy"] += int(x["modification"]["superheavy"])
-				sum["system"] += int(x["modification"]["system"])
-				sum["wing"] += int(x["modification"]["wing"])
+			var sum = SlotUtils.get_slot_sums(ship)
 			if _src["type"] == 0.0 and sum["superheavy"] <= 0:
 				_add.hide()
 			elif _src["type"] == 1.0 and sum["primary"] <= 0:
@@ -44,9 +32,8 @@ func _process(delta: float) -> void:
 	else:
 		_add.show()
 		_remove.hide()
-		
-		
-		
+
+
 func populate(weapon):
 	_src = weapon.duplicate(true)
 	_name.text = weapon.get("name")
@@ -63,7 +50,7 @@ func populate(weapon):
 		_param.text += "[Дистанция " +  weapon.get("range") + "] "
 	if weapon.get("damage") != "":
 		_param.text += "[Урон " + weapon.get("damage") + "] "
-	
+
 	if  weapon.get("tenacity") != "":
 		_param.text += "[Упорство " + weapon.get("tenacity") + "] "
 	_param.text += "[Очки " + str(int(weapon.get("points"))) + "]"

--- a/slot_utils.gd
+++ b/slot_utils.gd
@@ -1,0 +1,20 @@
+class_name SlotUtils
+
+static func get_slot_sums(ship: Dictionary) -> Dictionary:
+	var sum := {
+		"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
+		"escort": int(ship["support_slots"]["escorts"]),
+		"primary": int(ship["weapon_slots"]["primaries"]),
+		"superheavy": int(ship["weapon_slots"]["superheavy"]),
+		"system": int(ship["support_slots"]["systems"]),
+		"wing": int(ship["support_slots"]["wings"]),
+	}
+	for option in ship.get("option", []):
+		var mod := option.get("modification", {})
+		sum["auxiliary"] += int(mod.get("auxiliary", 0))
+		sum["escort"] += int(mod.get("escort", 0))
+		sum["primary"] += int(mod.get("primary", 0))
+		sum["superheavy"] += int(mod.get("superheavy", 0))
+		sum["system"] += int(mod.get("system", 0))
+		sum["wing"] += int(mod.get("wing", 0))
+	return sum


### PR DESCRIPTION
## Summary
- add SlotUtils utility to compute total slot counts for a ship
- use SlotUtils in weapon, system and escort wing panels
- replace leading spaces with single tabs to match project style

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af1485d6483208c177970e7df0c03