### PR TITLE
Add child count check in options.gd

### DIFF
--- a/options.gd
+++ b/options.gd
@@ -3,8 +3,11 @@ extends HBoxContainer
 
 
 func _ready() -> void:
-	for x in get_children():
-		if x.get_child(1).text == "0":
-			x.visible = false
-		else:
-			x.visible = true
+        for x in get_children():
+                if x.get_child_count() > 1:
+                        if x.get_child(1).text == "0":
+                                x.visible = false
+                        else:
+                                x.visible = true
+                else:
+                        push_warning("%s has no second child; skipping" % x.name)


### PR DESCRIPTION
## Summary
- Guard against accessing a non-existent second child in options
- Warn and skip processing when a node has fewer than two children

## Testing
- `godot --headless --no-window` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689af17157288320b647cc6a1e219612