### PR TITLE
refactor: centralize option type constants

### DIFF
--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const OptionTypes = preload("res://option_types.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -41,9 +43,9 @@ func _process(delta: float) -> void:
 				sum["superheavy"] += int(x["modification"]["superheavy"])
 				sum["system"] += int(x["modification"]["system"])
 				sum["wing"] += int(x["modification"]["wing"])
-			if _src["type"] == 0.0 and sum["escort"] <= 0:
+			if _src["type"] == OptionTypes.SUPPORT_ESCORT and sum["escort"] <= 0:
 				_add.hide()
-			elif _src["type"] == 1.0 and sum["wing"] <= 0:
+			elif _src["type"] == OptionTypes.SUPPORT_WING and sum["wing"] <= 0:
 				_add.hide()
 			if _src in ship["option"]:
 				_remove.show()
@@ -59,9 +61,9 @@ func _process(delta: float) -> void:
 func populate(system):
 	_src = system.duplicate(true)
 	_name.text = system.get("name")
-	if system.get("type") == 0.0:
+	if system.get("type") == OptionTypes.SUPPORT_ESCORT:
 		_tags.text = "Эскорт"
-	elif system.get("type") == 1.0:
+	elif system.get("type") == OptionTypes.SUPPORT_WING:
 		_tags.text = "Крыло"
 	if system.get("tags") != "":
 		_tags.text += ", " + system.get("tags")
@@ -75,7 +77,7 @@ func populate(system):
 	_discription.text = "[i]" + system.get("discription") + "[/i]"
 	if len(system.get("feats")) > 0:
 		var feat1 = system.get("feats").get(0)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == OptionTypes.FEAT_TACTIC:
 			_tactic1.visible = true
 			_tactic1_name.text = feat1.get("name")
 			_tactic1_tag.text = feat1.get("tags")
@@ -87,7 +89,7 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 	if len(system.get("feats")) > 1:
 		var feat1 = system.get("feats").get(1)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == OptionTypes.FEAT_TACTIC:
 			_tactic2.visible = true
 			_tactic2_name.text = feat1.get("name")
 			_tactic2_tag.text = feat1.get("tags")

--- a/Main_scane/Option_list/option_list.gd
+++ b/Main_scane/Option_list/option_list.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const OptionTypes = preload("res://option_types.gd")
+
 ## ───────────────────────────────────────────────────────────────────
 ## 1.  Экспортируемые ресурсы и пути
 ## ───────────────────────────────────────────────────────────────────
@@ -54,16 +56,16 @@ func _populate_all() -> void:
 	# эскорты / крылья
 	for e in raw.get("escorts_wings", []):
 		var n := eswg_scene.instantiate()
-		var idx := 4 if e.get("type") == 0.0 else 5   # 0=escort, 1=wing
+		var idx := 4 if e.get("type") == OptionTypes.SUPPORT_ESCORT else 5   # см. OptionTypes.SUPPORT_ESCORT/SUPPORT_WING
 		_slot_info[idx].node.add_child(n)
 		n.populate(e)
 
 func _type_to_index(t: float) -> int:
 	var x
 	match int(t):
-		0: x = 0     # superheavy
-		1: x = 1     # primaries
-		2: x = 2     # auxiliaries
+		OptionTypes.WEAPON_SUPERHEAVY: x = 0     # superheavy
+		OptionTypes.WEAPON_PRIMARY:    x = 1     # primaries
+		OptionTypes.WEAPON_AUXILIARY:  x = 2     # auxiliaries
 		_: x = -1
 	return x
 ## ───────────────────────────────────────────────────────────────────

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const OptionTypes = preload("res://option_types.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -67,7 +69,7 @@ func populate(system):
 	_discription.text = "[i]" + system.get("discription") + "[/i]"
 	if len(system.get("feats")) > 0:
 		var feat1 = system.get("feats").get(0)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == OptionTypes.FEAT_TACTIC:
 			_tactic1.visible = true
 			_tactic1_name.text = feat1.get("name")
 			_tactic1_tag.text = feat1.get("tags")
@@ -79,7 +81,7 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 	if len(system.get("feats")) > 1:
 		var feat1 = system.get("feats").get(1)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == OptionTypes.FEAT_TACTIC:
 			_tactic2.visible = true
 			_tactic2_name.text = feat1.get("name")
 			_tactic2_tag.text = feat1.get("tags")

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const OptionTypes = preload("res://option_types.gd")
+
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
@@ -28,11 +30,11 @@ func _process(delta: float) -> void:
 				sum["superheavy"] += int(x["modification"]["superheavy"])
 				sum["system"] += int(x["modification"]["system"])
 				sum["wing"] += int(x["modification"]["wing"])
-			if _src["type"] == 0.0 and sum["superheavy"] <= 0:
+			if _src["type"] == OptionTypes.WEAPON_SUPERHEAVY and sum["superheavy"] <= 0:
 				_add.hide()
-			elif _src["type"] == 1.0 and sum["primary"] <= 0:
+			elif _src["type"] == OptionTypes.WEAPON_PRIMARY and sum["primary"] <= 0:
 				_add.hide()
-			elif _src["type"] == 2.0 and sum["auxiliary"] <= 0:
+			elif _src["type"] == OptionTypes.WEAPON_AUXILIARY and sum["auxiliary"] <= 0:
 				_add.hide()
 			if _src in ship["option"]:
 				_remove.show()
@@ -50,11 +52,11 @@ func _process(delta: float) -> void:
 func populate(weapon):
 	_src = weapon.duplicate(true)
 	_name.text = weapon.get("name")
-	if weapon.get("type") == 0.0:
+	if weapon.get("type") == OptionTypes.WEAPON_SUPERHEAVY:
 		_tags.text = "Серхтяжелое, " + weapon.get("tags")
-	elif weapon.get("type") == 1.0:
+	elif weapon.get("type") == OptionTypes.WEAPON_PRIMARY:
 		_tags.text = "Основное, " + weapon.get("tags")
-	elif weapon.get("type") == 2.0:
+	elif weapon.get("type") == OptionTypes.WEAPON_AUXILIARY:
 		_tags.text = "Вспомогательное"
 		if weapon.get("tags") != "":
 			_tags.text += ", " + weapon.get("tags")

--- a/option_types.gd
+++ b/option_types.gd
@@ -1,0 +1,14 @@
+# Общие константы типов опций и связанных объектов.
+class_name OptionTypes
+
+# Типы оружия
+const WEAPON_SUPERHEAVY := 0.0
+const WEAPON_PRIMARY := 1.0
+const WEAPON_AUXILIARY := 2.0
+
+# Типы поддержки (эскорты/крылья)
+const SUPPORT_ESCORT := 0.0
+const SUPPORT_WING := 1.0
+
+# Типы особенностей (feat)
+const FEAT_TACTIC := 2.0


### PR DESCRIPTION
## Summary
- add shared option type constants for weapons, support and feats
- replace numeric type checks in option scripts with descriptive constants
- normalize tab indentation in option scripts

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689af176299083209f61f1d35f623d74