### PR TITLE
Replace magic numbers with option constants

### DIFF
--- a/Main_scane/Hull_list/hulls_list.gd
+++ b/Main_scane/Hull_list/hulls_list.gd
@@ -3,6 +3,7 @@ extends VBoxContainer                        # навесьте на узел Hu
 
 @export var json_path := "user://battlegroup_data.json"
 @export var hull_scene:= preload("res://support_scanes/hull.tscn")    # drag-and-drop Hull.tscn в инспекторе
+const Opt = preload("res://option_types.gd")
 
 @onready var _frigate: VBoxContainer = $Hulls_list/VBoxContainer/Frigate
 @onready var _carrier: VBoxContainer = $Hulls_list/VBoxContainer/Carrier
@@ -21,11 +22,11 @@ func _ready() -> void:
 
 func _spawn_hull(hull_data: Dictionary) -> void:
 	var hull := hull_scene.instantiate()
-	if hull_data["class"] == 0.0:
+	if int(hull_data["class"]) == BattlegroupData.ShipClass.FRIGATE:
 		_frigate.add_child(hull)
-	elif hull_data["class"] == 1.0:
+	elif int(hull_data["class"]) == BattlegroupData.ShipClass.CARRIER:
 		_carrier.add_child(hull)
-	elif hull_data["class"] == 2.0:
+	elif int(hull_data["class"]) == BattlegroupData.ShipClass.BATTLESHIP:
 		_battleship.add_child(hull)
 	hull.get_child(0).populate(hull_data)
 	#hull.get_child(0).hull_added.connect(BattlegroupData.add_hull)
@@ -48,13 +49,13 @@ func _on_option_button_item_selected(index: int) -> void:
 	_frigate.hide()
 	_carrier.hide()
 	_battleship.hide()
-	if  _options.selected == 1:
+	if  _options.selected == Opt.HullFilter.FRIGATE:
 		_frigate.show()
-	elif  _options.selected == 2:
+	elif  _options.selected == Opt.HullFilter.CARRIER:
 		_carrier.show()
-	elif  _options.selected == 3:
+	elif  _options.selected == Opt.HullFilter.BATTLESHIP:
 		_battleship.show()
-	elif _options.selected == 0:
+	elif _options.selected == Opt.HullFilter.ALL:
 		_frigate.show()
 		_carrier.show()
 		_battleship.show()

--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -1,6 +1,7 @@
 extends PanelContainer
 
 const SlotUtils = preload("res://slot_utils.gd")
+const Opt = preload("res://option_types.gd")
 
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
@@ -22,16 +23,16 @@ const SlotUtils = preload("res://slot_utils.gd")
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _remove: MarginContainer = $VBoxContainer/Button2
 
-var _src: Dictionary	
+var _src: Dictionary
 
 func _process(delta: float) -> void:
 	if _src.size() != 0 and BattlegroupData.current_ship != -1:
 		var ship = BattlegroupData.ships[BattlegroupData.current_ship]
 		if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
 			var sum = SlotUtils.get_slot_sums(ship)
-			if _src["type"] == 0.0 and sum["escort"] <= 0:
+			if _src["type"] == Opt.Support.ESCORT and sum["escort"] <= 0:
 				_add.hide()
-			elif _src["type"] == 1.0 and sum["wing"] <= 0:
+			elif _src["type"] == Opt.Support.WING and sum["wing"] <= 0:
 				_add.hide()
 			if _src in ship["option"]:
 				_remove.show()
@@ -47,9 +48,9 @@ func _process(delta: float) -> void:
 func populate(system):
 	_src = system.duplicate(true)
 	_name.text = system.get("name")
-	if system.get("type") == 0.0:
+	if system.get("type") == Opt.Support.ESCORT:
 		_tags.text = "Эскорт"
-	elif system.get("type") == 1.0:
+	elif system.get("type") == Opt.Support.WING:
 		_tags.text = "Крыло"
 	if system.get("tags") != "":
 		_tags.text += ", " + system.get("tags")
@@ -63,7 +64,7 @@ func populate(system):
 	_discription.text = "[i]" + system.get("discription") + "[/i]"
 	if system.get("feats").size() > 0:
 		var feat1 = system.get("feats").get(0)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == Opt.FEAT_TACTIC:
 			_tactic1.visible = true
 			_tactic1_name.text = feat1.get("name")
 			_tactic1_tag.text = feat1.get("tags")
@@ -75,7 +76,7 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 	if system.get("feats").size() > 1:
 		var feat1 = system.get("feats").get(1)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == Opt.FEAT_TACTIC:
 			_tactic2.visible = true
 			_tactic2_name.text = feat1.get("name")
 			_tactic2_tag.text = feat1.get("tags")

--- a/Main_scane/Option_list/option_list.gd
+++ b/Main_scane/Option_list/option_list.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+const Opt = preload("res://option_types.gd")
+
 ## ───────────────────────────────────────────────────────────────────
 ## 1.  Экспортируемые ресурсы и пути
 ## ───────────────────────────────────────────────────────────────────
@@ -12,12 +14,12 @@ extends PanelContainer
 ## 2.  Контейнеры категорий
 ## ───────────────────────────────────────────────────────────────────
 @onready var _slot_info := {          # индекс OptionButton → {key, node}
-	0: { "key":"superheavy", "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Superheavy },
-	1: { "key":"primaries",  "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Primary   },
-	2: { "key":"auxiliaries","node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Auxiliry  },
-	3: { "key":"systems",    "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/System    },
-	4: { "key":"escorts",    "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Escort    },
-	5: { "key":"wings",      "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Wing      },
+	Opt.SlotIndex.SUPERHEAVY:  { "key":"superheavy",  "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Superheavy },
+	Opt.SlotIndex.PRIMARIES:   { "key":"primaries",   "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Primary   },
+	Opt.SlotIndex.AUXILIARIES:{ "key":"auxiliaries","node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Auxiliry  },
+	Opt.SlotIndex.SYSTEMS:     { "key":"systems",     "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/System    },
+	Opt.SlotIndex.ESCORTS:     { "key":"escorts",     "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Escort    },
+	Opt.SlotIndex.WINGS:       { "key":"wings",       "node": $MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer/Wing      },
 }
 
 @onready var _close : Button = $MarginContainer/VBoxContainer/HBoxContainer/Button
@@ -31,8 +33,8 @@ func _ready() -> void:
 	BattlegroupData.option_change.connect(_apply_ship_filter)
 	# сразу применяем фильтр для первого выбранного корабля (если есть)
 	_apply_ship_filter()
-	
-	
+
+
 
 func _populate_all() -> void:
 	var raw := _load_json(json_path)
@@ -48,22 +50,22 @@ func _populate_all() -> void:
 	# системы
 	for s in raw.get("systems", []):
 		var n := system_scene.instantiate()
-		_slot_info[3]["node"].add_child(n)     # 3 → systems
+		_slot_info[Opt.SlotIndex.SYSTEMS]["node"].add_child(n)     # systems
 		n.populate(s)
 
 	# эскорты / крылья
 	for e in raw.get("escorts_wings", []):
 		var n := eswg_scene.instantiate()
-		var idx := 4 if e.get("type") == 0.0 else 5   # 0=escort, 1=wing
+		var idx := Opt.SlotIndex.ESCORTS if e.get("type") == Opt.Support.ESCORT else Opt.SlotIndex.WINGS   # support type
 		_slot_info[idx]["node"].add_child(n)
 		n.populate(e)
 
 func _type_to_index(t: float) -> int:
 	var x
 	match int(t):
-		0: x = 0     # superheavy
-		1: x = 1     # primaries
-		2: x = 2     # auxiliaries
+		Opt.Weapon.SUPERHEAVY: x = Opt.SlotIndex.SUPERHEAVY
+		Opt.Weapon.PRIMARY:    x = Opt.SlotIndex.PRIMARIES
+		Opt.Weapon.AUXILIARY:  x = Opt.SlotIndex.AUXILIARIES
 		_: x = -1
 	return x
 ## ───────────────────────────────────────────────────────────────────
@@ -95,8 +97,8 @@ func _apply_ship_filter() -> void:
 func _on_option_button_item_selected(index: int) -> void:
 	_apply_ship_filter()   # актуализируем visibile = true/false
 
-	# если выбран «Все» (6) — оставляем как есть
-	if index == 6:
+	# если выбран «Все» — оставляем как есть
+	if index == Opt.SlotIndex.ALL:
 		return
 
 	# иначе скрываем всё, кроме нужного индекса

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -1,6 +1,7 @@
 extends PanelContainer
 
 const SlotUtils = preload("res://slot_utils.gd")
+const Opt = preload("res://option_types.gd")
 
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
@@ -22,7 +23,7 @@ const SlotUtils = preload("res://slot_utils.gd")
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _remove: MarginContainer = $VBoxContainer/Button2
 
-var _src: Dictionary	
+var _src: Dictionary
 
 func _process(delta: float) -> void:
 	if _src.size() != 0 and BattlegroupData.current_ship != -1:
@@ -55,7 +56,7 @@ func populate(system):
 	_discription.text = "[i]" + system.get("discription") + "[/i]"
 	if system.get("feats").size() > 0:
 		var feat1 = system.get("feats").get(0)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == Opt.FEAT_TACTIC:
 			_tactic1.visible = true
 			_tactic1_name.text = feat1.get("name")
 			_tactic1_tag.text = feat1.get("tags")
@@ -67,7 +68,7 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 	if system.get("feats").size() > 1:
 		var feat1 = system.get("feats").get(1)
-		if feat1.get("type") == 2.0:
+		if feat1.get("type") == Opt.FEAT_TACTIC:
 			_tactic2.visible = true
 			_tactic2_name.text = feat1.get("name")
 			_tactic2_tag.text = feat1.get("tags")

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -1,6 +1,7 @@
 extends PanelContainer
 
 const SlotUtils = preload("res://slot_utils.gd")
+const Opt = preload("res://option_types.gd")
 
 @onready var _name: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Name
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
@@ -16,11 +17,11 @@ func _process(delta: float) -> void:
 		var ship = BattlegroupData.ships[BattlegroupData.current_ship]
 		if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
 			var sum = SlotUtils.get_slot_sums(ship)
-			if _src["type"] == 0.0 and sum["superheavy"] <= 0:
+			if _src["type"] == Opt.Weapon.SUPERHEAVY and sum["superheavy"] <= 0:
 				_add.hide()
-			elif _src["type"] == 1.0 and sum["primary"] <= 0:
+			elif _src["type"] == Opt.Weapon.PRIMARY and sum["primary"] <= 0:
 				_add.hide()
-			elif _src["type"] == 2.0 and sum["auxiliary"] <= 0:
+			elif _src["type"] == Opt.Weapon.AUXILIARY and sum["auxiliary"] <= 0:
 				_add.hide()
 			if _src in ship["option"]:
 				_remove.show()
@@ -37,11 +38,11 @@ func _process(delta: float) -> void:
 func populate(weapon):
 	_src = weapon.duplicate(true)
 	_name.text = weapon.get("name")
-	if weapon.get("type") == 0.0:
+	if weapon.get("type") == Opt.Weapon.SUPERHEAVY:
 		_tags.text = "Серхтяжелое, " + weapon.get("tags")
-	elif weapon.get("type") == 1.0:
+	elif weapon.get("type") == Opt.Weapon.PRIMARY:
 		_tags.text = "Основное, " + weapon.get("tags")
-	elif weapon.get("type") == 2.0:
+	elif weapon.get("type") == Opt.Weapon.AUXILIARY:
 		_tags.text = "Вспомогательное"
 		if weapon.get("tags") != "":
 			_tags.text += ", " + weapon.get("tags")

--- a/option_types.gd
+++ b/option_types.gd
@@ -1,0 +1,36 @@
+class_name OptionTypes
+
+# Weapon categories
+enum Weapon {
+	SUPERHEAVY,
+	PRIMARY,
+	AUXILIARY,
+}
+
+# Support options (escorts and wings)
+enum Support {
+	ESCORT,
+	WING,
+}
+
+# Indices of option categories in option lists
+enum SlotIndex {
+	SUPERHEAVY,
+	PRIMARIES,
+	AUXILIARIES,
+	SYSTEMS,
+	ESCORTS,
+	WINGS,
+	ALL,
+}
+
+# Filter values for hull list OptionButton
+enum HullFilter {
+	ALL,
+	FRIGATE,
+	CARRIER,
+	BATTLESHIP,
+}
+
+# Feat type identifier
+const FEAT_TACTIC = 2

--- a/support_scanes/hull.gd
+++ b/support_scanes/hull.gd
@@ -35,14 +35,14 @@ func populate(data: Dictionary) -> void:
 	_src = data.duplicate(true)
 	_name.text     = data.get("name")
 	_image.texture = load("res://hulls/" + data.get("name").replace("\n", " ") + ".png")
-	match str(data.get("class")):
-		"0.0":
+	match int(data.get("class")):
+		BattlegroupData.ShipClass.FRIGATE:
 			_type.text = "Фрегат"
-		"1.0":
+		BattlegroupData.ShipClass.CARRIER:
 			_type.text = "Авианосец"
-		"2.0":
+		BattlegroupData.ShipClass.BATTLESHIP:
 			_type.text = "Эсминец"
-			
+
 	_points.text     = str(data.get("points"))
 	_hp.text         = str(data.get("hp"))
 	_defense.text    = str(data.get("defense"))
@@ -56,7 +56,7 @@ func populate(data: Dictionary) -> void:
 	# описание и черта (feats[0])
 	for x in data.get("feats"):
 		_spawn_feat(x)
-	
+
 	_option_1.refresh_visibility()
 	_connect_buttons()           # см. ниже
 	_update_buttons()            # выставляем видимость
@@ -72,7 +72,7 @@ func _update_buttons() -> void:
 	var cls: int = _src["class"]
 	var already_added := _count_added()
 	var reached_limit := not BattlegroupData.can_add(cls)
-	
+
 	_remove_btn.visible = already_added > 0
 	_add_btn.visible    = not reached_limit \
 						  and BattlegroupData.point + int(_src.get("points")) <= 20
@@ -93,7 +93,7 @@ func _on_remove_pressed() -> void:
 func _spawn_feat(feat_data) -> void:
 	var feat := FEAT_SCENE.instantiate()
 	_feat_box.add_child(feat)
-	feat.populate(feat_data) 
+	feat.populate(feat_data)
 
 func _is_same_template(h: Dictionary) -> bool:
 	# сравниваем по «базовому» имени корпуса, остальные поля (ship_name/option/flagman) игнорируем


### PR DESCRIPTION
## Summary
- centralize option identifiers in new `OptionTypes` module
- use these constants throughout option and hull scripts instead of numeric literals
- clean up comments and duplicate declarations
- normalize indentation to a single tab across option and hull scripts

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689b12b0da548320ac43af2cf280809d