### PR TITLE
Handle tags without numeric suffix

### DIFF
--- a/Main_scane/Option_list/option_list.gd
+++ b/Main_scane/Option_list/option_list.gd
@@ -10,6 +10,7 @@ const Opt = preload("res://option_types.gd")
 @export var system_scene   := preload("res://Main_scane/Option_list/system.tscn")
 @export var eswg_scene     := preload("res://Main_scane/Option_list/escort_wing.tscn")
 @onready var _tag_button: OptionButton = $MarginContainer/VBoxContainer/OptionButton2
+var _tag_suffix_re := RegEx.new()
 
 ## ───────────────────────────────────────────────────────────────────
 ## 2.  Контейнеры категорий
@@ -29,42 +30,43 @@ const Opt = preload("res://option_types.gd")
 ## 3.  Загрузка JSON и наполнение
 ## ───────────────────────────────────────────────────────────────────
 func _ready() -> void:
-		_populate_all()
-		# слушаем выбор корабля
-		BattlegroupData.option_change.connect(_apply_filters)
-		# сразу применяем фильтр для первого выбранного корабля (если есть)
-		_apply_filters()
+	_tag_suffix_re.compile("\\s*[\\-–+]?\\d+$")
+	_populate_all()
+	# слушаем выбор корабля
+	BattlegroupData.option_change.connect(_apply_filters)
+	# сразу применяем фильтр для первого выбранного корабля (если есть)
+	_apply_filters()
 
 
 
 func _populate_all() -> void:
-		var raw = _load_json(json_path)
-		if raw.is_empty():
-				return
+	var raw = _load_json(json_path)
+	if raw.is_empty():
+		return
 
-		var tag_map := {}
-		_collect_tags(raw, tag_map)
+	var tag_map := {}
+	_collect_tags(raw, tag_map)
 
-		# оружие
-		for w in raw.get("weapons", []):
-				var n := weapon_scene.instantiate()
-				_slot_info[_type_to_index(w.get("type", -1))]["node"].add_child(n)
-				n.populate(w)
+	# оружие
+	for w in raw.get("weapons", []):
+		var n := weapon_scene.instantiate()
+		_slot_info[_type_to_index(w.get("type", -1))]["node"].add_child(n)
+		n.populate(w)
 
-		# системы
-		for s in raw.get("systems", []):
-				var n := system_scene.instantiate()
-				_slot_info[Opt.SlotIndex.SYSTEMS]["node"].add_child(n)     # systems
-				n.populate(s)
+	# системы
+	for s in raw.get("systems", []):
+		var n := system_scene.instantiate()
+		_slot_info[Opt.SlotIndex.SYSTEMS]["node"].add_child(n)     # systems
+		n.populate(s)
 
-		# эскорты / крылья
-		for e in raw.get("escorts_wings", []):
-				var n := eswg_scene.instantiate()
-				var idx := Opt.SlotIndex.ESCORTS if e.get("type") == Opt.Support.ESCORT else Opt.SlotIndex.WINGS   # support type
-				_slot_info[idx]["node"].add_child(n)
-				n.populate(e)
+	# эскорты / крылья
+	for e in raw.get("escorts_wings", []):
+		var n := eswg_scene.instantiate()
+		var idx := Opt.SlotIndex.ESCORTS if e.get("type") == Opt.Support.ESCORT else Opt.SlotIndex.WINGS   # support type
+		_slot_info[idx]["node"].add_child(n)
+		n.populate(e)
 
-		_populate_tag_button(tag_map.keys())
+	_populate_tag_button(tag_map.keys())
 
 func _type_to_index(t: float) -> int:
 	var x
@@ -78,60 +80,60 @@ func _type_to_index(t: float) -> int:
 ## 4.  Фильтрация по выбранному кораблю
 ## ───────────────────────────────────────────────────────────────────
 func _apply_filters() -> void:
-		# сбросить видимость
-		for d in _slot_info.values():
-				for c in d["node"].get_children():
-						c.visible = true
-				d["node"].visible = false
+	# сбросить видимость
+	for d in _slot_info.values():
+		for c in d["node"].get_children():
+			c.visible = true
+		d["node"].visible = false
 
-		var idx := int(BattlegroupData.current_ship)
-		if idx < 0 or idx >= BattlegroupData.ships.size():
-				return                                     # корабль не выбран
+	var idx := int(BattlegroupData.current_ship)
+	if idx < 0 or idx >= BattlegroupData.ships.size():
+		return                                     # корабль не выбран
 
-		var ship = BattlegroupData.ships[idx]
-		var weapon  = ship["weapon_slots"]
-		var support = ship["support_slots"]
+	var ship = BattlegroupData.ships[idx]
+	var weapon  = ship["weapon_slots"]
+	var support = ship["support_slots"]
 
-		# показываем только те категории, где есть слоты (>0)
+	# показываем только те категории, где есть слоты (>0)
+	for i in _slot_info:
+		var k = _slot_info[i]["key"]
+		var cnt := int(weapon.get(k, "0")) if k in weapon else int(support.get(k, "0"))
+		if cnt > 0:
+			_slot_info[i]["node"].visible = true
+
+	# фильтр по категории
+	var cat_idx = $MarginContainer/VBoxContainer/OptionButton.selected
+	if cat_idx != Opt.SlotIndex.ALL:
 		for i in _slot_info:
-				var k = _slot_info[i]["key"]
-				var cnt := int(weapon.get(k, "0")) if k in weapon else int(support.get(k, "0"))
-				if cnt > 0:
-						_slot_info[i]["node"].visible = true
+			_slot_info[i]["node"].visible = (i == cat_idx) and _slot_info[i]["node"].visible
 
-		# фильтр по категории
-		var cat_idx = $MarginContainer/VBoxContainer/OptionButton.selected
-		if cat_idx != Opt.SlotIndex.ALL:
-				for i in _slot_info:
-						_slot_info[i]["node"].visible = (i == cat_idx) and _slot_info[i]["node"].visible
-
-		# фильтр по тегу
-		var tag_text := _tag_button.get_item_text(_tag_button.selected)
-		if tag_text != "Все":
-			for d in _slot_info.values():
-				if d["node"].visible:
-					for c in d["node"].get_children():
-						var has := false
-						for t in c._src.get("tags", "").split(",", false):
-							if t.strip_edges() == tag_text:
-								has = true
-								break
-						c.visible = has
-					var any := false
-					for c in d["node"].get_children():
-						if c.visible:
-							any = true
-							break
-					d["node"].visible = any
+	# фильтр по тегу
+	var tag_text := _tag_button.get_item_text(_tag_button.selected)
+	if tag_text != "Все":
+	for d in _slot_info.values():
+		if d["node"].visible:
+		for c in d["node"].get_children():
+			var has := false
+			for t in c._src.get("tags", "").split(",", false):
+			if _clean_tag(t) == tag_text:
+				has = true
+				break
+			c.visible = has
+		var any := false
+		for c in d["node"].get_children():
+			if c.visible:
+			any = true
+			break
+		d["node"].visible = any
 
 ## ───────────────────────────────────────────────────────────────────
 ## 5.  Реакция на выбор в OptionButton
 ## ───────────────────────────────────────────────────────────────────
 func _on_option_button_item_selected(index: int) -> void:
-		_apply_filters()
+	_apply_filters()
 
 func _on_option_button2_item_selected(index: int) -> void:
-		_apply_filters()
+	_apply_filters()
 
 ## ───────────────────────────────────────────────────────────────────
 ## 6.  JSON utils
@@ -148,25 +150,28 @@ func _load_json(path: String):
 	return parsed
 
 func _on_button_pressed() -> void:
-		$"../Commander_interface".show()
-		hide()
+	$"../Commander_interface".show()
+	hide()
+
+func _clean_tag(t: String) -> String:
+	return _tag_suffix_re.sub(t.strip_edges(), "", true)
 
 func _collect_tags(obj, tags: Dictionary) -> void:
-		if obj is Dictionary:
-				if obj.has("tags"):
-						for t in obj["tags"].split(",", false):
-								t = t.strip_edges()
-								if t != "":
-										tags[t] = true
-				for v in obj.values():
-						_collect_tags(v, tags)
-		elif obj is Array:
-				for v in obj:
-						_collect_tags(v, tags)
+	if obj is Dictionary:
+		if obj.has("tags"):
+			for t in obj["tags"].split(",", false):
+				t = _clean_tag(t)
+				if t != "":
+					tags[t] = true
+		for v in obj.values():
+			_collect_tags(v, tags)
+	elif obj is Array:
+		for v in obj:
+			_collect_tags(v, tags)
 
 func _populate_tag_button(tag_list: Array) -> void:
-		_tag_button.clear()
-		_tag_button.add_item("Все")
-		tag_list.sort()
-		for t in tag_list:
-				_tag_button.add_item(t)
+	_tag_button.clear()
+	_tag_button.add_item("Все")
+	tag_list.sort()
+	for t in tag_list:
+		_tag_button.add_item(t)


### PR DESCRIPTION
## Summary
- Normalize tags by removing trailing numeric values during collection and filtering
- Centralize tag cleaning with a regex-based helper
- Use single-tab indentation throughout option list script

## Testing
- `godot --headless --check-only project.godot` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b63b6cd808320a55b868d988f9a7d