### PR TITLE
Update options with current ship slots

### DIFF
--- a/options.gd
+++ b/options.gd
@@ -1,13 +1,51 @@
 extends HBoxContainer
 
+const SlotUtils = preload("res://slot_utils.gd")
 
+@onready var _labels := {
+	"superheavy": $Superheavies/Superheavy,
+	"primaries": $Primaries/Primary,
+	"auxiliaries": $Auxiliaries/Auxiliary,
+	"wings": $Wings/Wing,
+	"escorts": $Escorts/Escort,
+	"systems": $Systems/System,
+}
 
 func _ready() -> void:
-	for x in get_children():
-		if x.get_child_count() > 1:
-			if x.get_child(1).text == "0":
-				x.visible = false
-			else:
-				x.visible = true
-		else:
-				push_warning("%s has no second child; skipping" % x.name)
+	visibility_changed.connect(_on_visibility_changed)
+	_update_from_ship()
+
+func _on_visibility_changed() -> void:
+	if visible:
+		_update_from_ship()
+
+func _update_from_ship() -> void:
+        var idx := int(BattlegroupData.current_ship)
+        if idx < 0 or idx >= BattlegroupData.ships.size():
+                return
+        var ship := BattlegroupData.ships[idx]
+        var sum := SlotUtils.get_slot_sums(ship)
+        var used := SlotUtils.get_slot_usage(ship)
+        _labels["superheavy"].text = "%d/%d" % [used["superheavy"], sum["superheavy"]]
+        _labels["primaries"].text = "%d/%d" % [used["primary"], sum["primary"]]
+        _labels["auxiliaries"].text = "%d/%d" % [used["auxiliary"], sum["auxiliary"]]
+        _labels["wings"].text = "%d/%d" % [used["wing"], sum["wing"]]
+        _labels["escorts"].text = "%d/%d" % [used["escort"], sum["escort"]]
+        _labels["systems"].text = "%d/%d" % [used["system"], sum["system"]]
+        _refresh_visibility()
+
+func _refresh_visibility() -> void:
+        var any_visible := false
+        for c in get_children():
+                if c.get_child_count() > 1:
+                        var lbl = c.get_child(1)
+                        var parts = lbl.text.split("/")
+                        var show := parts.size() == 2 and int(parts[1]) > 0
+                        c.visible = show
+                        if show:
+                                any_visible = true
+                else:
+                        push_warning("%s has no second child; skipping" % c.name)
+			c.visible = true
+			any_visible = true
+	visible = any_visible

--- a/slot_utils.gd
+++ b/slot_utils.gd
@@ -1,5 +1,7 @@
 class_name SlotUtils
 
+const Opt = preload("res://option_types.gd")
+
 static func get_slot_sums(ship: Dictionary) -> Dictionary:
 	var sum = {
 		"auxiliary": int(ship["weapon_slots"]["auxiliaries"]),
@@ -9,12 +11,41 @@ static func get_slot_sums(ship: Dictionary) -> Dictionary:
 		"system": int(ship["support_slots"]["systems"]),
 		"wing": int(ship["support_slots"]["wings"]),
 	}
-	for option in ship.get("option", []):
-		var mod = option.get("modification", {})
-		sum["auxiliary"] += int(mod.get("auxiliary", 0))
-		sum["escort"] += int(mod.get("escort", 0))
-		sum["primary"] += int(mod.get("primary", 0))
-		sum["superheavy"] += int(mod.get("superheavy", 0))
-		sum["system"] += int(mod.get("system", 0))
-		sum["wing"] += int(mod.get("wing", 0))
-	return sum
+        for option in ship.get("option", []):
+                var mod = option.get("modification", {})
+                sum["auxiliary"] += int(mod.get("auxiliary", 0))
+                sum["escort"] += int(mod.get("escort", 0))
+                sum["primary"] += int(mod.get("primary", 0))
+                sum["superheavy"] += int(mod.get("superheavy", 0))
+                sum["system"] += int(mod.get("system", 0))
+                sum["wing"] += int(mod.get("wing", 0))
+        return sum
+
+static func get_slot_usage(ship: Dictionary) -> Dictionary:
+        var used = {
+                "auxiliary": 0,
+                "escort": 0,
+                "primary": 0,
+                "superheavy": 0,
+                "system": 0,
+                "wing": 0,
+        }
+        for option in ship.get("option", []):
+                if option.has("type"):
+                        if option.has("hp"):
+                                match int(option["type"]):
+                                        Opt.Support.ESCORT:
+                                                used["escort"] += 1
+                                        Opt.Support.WING:
+                                                used["wing"] += 1
+                        else:
+                                match int(option["type"]):
+                                        Opt.Weapon.SUPERHEAVY:
+                                                used["superheavy"] += 1
+                                        Opt.Weapon.PRIMARY:
+                                                used["primary"] += 1
+                                        Opt.Weapon.AUXILIARY:
+                                                used["auxiliary"] += 1
+                else:
+                        used["system"] += 1
+        return used


### PR DESCRIPTION
## Summary
- show installed and total slot counts for the selected ship
- hide categories with no available slots

## Testing
- `gdlint options.gd slot_utils.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6b21b5dc8320b586c0d4b9bd76ed