### PR TITLE
Count option costs in battlegroup points

### DIFF
--- a/Main_scane/Commander/ship.gd
+++ b/Main_scane/Commander/ship.gd
@@ -131,13 +131,14 @@ func _on_name_changed(new_name : String) -> void:
 	_dict["ship_name"] = new_name
 
 func _on_flagman_toggled(on : bool) -> void:
-	_dict["flagman"] = on
-	if on:
-		_add_flagship_option()
-	else:
-		_remove_flagship_option()
-	_recalc_and_update_display()
-	BattlegroupData.emit_signal("battlegroup_change")
+        _dict["flagman"] = on
+        if on:
+                _add_flagship_option()
+        else:
+                _remove_flagship_option()
+        _recalc_and_update_display()
+        BattlegroupData.refresh_point()
+        BattlegroupData.emit_signal("battlegroup_change")
 
 func _on_option_pressed() -> void:
 	BattlegroupData.current_ship = _index

--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -88,9 +88,11 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -80,10 +80,12 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()
 
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -60,9 +60,11 @@ func populate(weapon):
 
 
 func _on_add_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()
 
 func _on_remove_pressed() -> void:
-	BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
-	BattlegroupData.option_change.emit()
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        BattlegroupData.refresh_point()
+        BattlegroupData.option_change.emit()

--- a/battlegroup_data.gd
+++ b/battlegroup_data.gd
@@ -89,9 +89,13 @@ func can_add(cls: int) -> bool:
 
 
 func refresh_point():
-	point = 0
-	for x in ships:
-		point += int(x.get("points"))
+        point = 0
+        for ship in ships:
+                var total := int(ship.get("points", 0))
+                for opt in ship.get("option", []):
+                        total += int(opt.get("points", 0))
+                        total += int(opt.get("modification", {}).get("point", 0))
+                point += total
 
 
 func change_on_option():


### PR DESCRIPTION
## Summary
- include option costs when recalculating battlegroup points
- update option add/remove handlers to refresh totals
- refresh points when toggling flagship status

## Testing
- `godot --version` *(fails: command not found)*
- `gdlint battlegroup_data.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c95860f8c8320ba0c2dc6ce170060