### PR TITLE
feat: enforce unique options and improve add/remove

### DIFF
--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -26,24 +26,47 @@ const Opt = preload("res://option_types.gd")
 var _src: Dictionary
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.current_ship != -1:
-		var ship = BattlegroupData.ships[BattlegroupData.current_ship]
-		if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
-			var sum = SlotUtils.get_slot_sums(ship)
-			if _src["type"] == Opt.Support.ESCORT and sum["escort"] <= 0:
-				_add.hide()
-			elif _src["type"] == Opt.Support.WING and sum["wing"] <= 0:
-				_add.hide()
-			if _src in ship["option"]:
-				_remove.show()
-			else:
-				_remove.hide()
-		else:
-			_add.show()
-			_remove.hide()
-	else:
-		_add.show()
-		_remove.hide()
+        _update_buttons()
+
+func _update_buttons() -> void:
+        var show_add := false
+        var show_remove := false
+        if _src.size() != 0 and BattlegroupData.current_ship != -1 and BattlegroupData.ships.size() != 0:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                var sum = SlotUtils.get_slot_sums(ship)
+                var used = SlotUtils.get_slot_usage(ship)
+                var key := _src["type"] == Opt.Support.ESCORT ? "escort" : "wing"
+                var capacity := sum.get(key, 0) + int(_src.get("modification", {}).get(key, 0))
+                var points := int(_src.get("points", 0)) + int(_src.get("modification", {}).get("point", 0))
+                show_add = used.get(key, 0) < capacity \
+                        and BattlegroupData.point + points <= 20 \
+                        and not (_has_unique_tag(_src) and _is_unique_taken())
+                show_remove = _count_added(ship) > 0
+        _add.visible = show_add
+        _remove.visible = show_remove
+
+func _has_unique_tag(opt: Dictionary) -> bool:
+        for t in opt.get("tags", "").split(",", false):
+                if t.strip_edges().to_lower() == "уникальное":
+                        return true
+        return false
+
+func _is_unique_taken() -> bool:
+        for s in BattlegroupData.ships:
+                for o in s.get("option", []):
+                        if o.get("name") == _src.get("name"):
+                                return true
+        return false
+
+func _is_same_template(o: Dictionary) -> bool:
+        return o.get("name") == _src.get("name")
+
+func _count_added(ship: Dictionary) -> int:
+        var n := 0
+        for o in ship.get("option", []):
+                if _is_same_template(o):
+                        n += 1
+        return n
 
 func populate(system):
 	_src = system.duplicate(true)
@@ -88,11 +111,16 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        var opt = _src.duplicate(true)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(opt)
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()
 
 func _on_remove_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        var arr = BattlegroupData.ships[BattlegroupData.current_ship]["option"]
+        for i in range(arr.size() - 1, -1, -1):
+                if _is_same_template(arr[i]):
+                        arr.remove_at(i)
+                        break
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -26,22 +26,46 @@ const Opt = preload("res://option_types.gd")
 var _src: Dictionary
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.current_ship != -1:
-		var ship = BattlegroupData.ships[BattlegroupData.current_ship]
-		if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
-			var sum = SlotUtils.get_slot_sums(ship)
-			if sum["system"] <= 0:
-				_add.hide()
-			if _src in ship["option"]:
-				_remove.show()
-			else:
-				_remove.hide()
-		else:
-			_add.show()
-			_remove.hide()
-	else:
-		_add.show()
-		_remove.hide()
+        _update_buttons()
+
+func _update_buttons() -> void:
+        var show_add := false
+        var show_remove := false
+        if _src.size() != 0 and BattlegroupData.current_ship != -1 and BattlegroupData.ships.size() != 0:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                var sum = SlotUtils.get_slot_sums(ship)
+                var used = SlotUtils.get_slot_usage(ship)
+                var capacity := sum.get("system", 0) + int(_src.get("modification", {}).get("system", 0))
+                var points := int(_src.get("points", 0)) + int(_src.get("modification", {}).get("point", 0))
+                show_add = used.get("system", 0) < capacity \
+                        and BattlegroupData.point + points <= 20 \
+                        and not (_has_unique_tag(_src) and _is_unique_taken())
+                show_remove = _count_added(ship) > 0
+        _add.visible = show_add
+        _remove.visible = show_remove
+
+func _has_unique_tag(opt: Dictionary) -> bool:
+        for t in opt.get("tags", "").split(",", false):
+                if t.strip_edges().to_lower() == "уникальное":
+                        return true
+        return false
+
+func _is_unique_taken() -> bool:
+        for s in BattlegroupData.ships:
+                for o in s.get("option", []):
+                        if o.get("name") == _src.get("name"):
+                                return true
+        return false
+
+func _is_same_template(o: Dictionary) -> bool:
+        return o.get("name") == _src.get("name")
+
+func _count_added(ship: Dictionary) -> int:
+        var n := 0
+        for o in ship.get("option", []):
+                if _is_same_template(o):
+                        n += 1
+        return n
 
 func populate(system):
 	_src = system.duplicate(true)
@@ -80,12 +104,17 @@ func populate(system):
 			_maneveue1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        var opt = _src.duplicate(true)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(opt)
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()
 
 
 func _on_remove_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        var arr = BattlegroupData.ships[BattlegroupData.current_ship]["option"]
+        for i in range(arr.size() - 1, -1, -1):
+                if _is_same_template(arr[i]):
+                        arr.remove_at(i)
+                        break
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -13,26 +13,51 @@ const Opt = preload("res://option_types.gd")
 var _src: Dictionary
 
 func _process(delta: float) -> void:
-	if _src.size() != 0 and BattlegroupData.current_ship != -1 and BattlegroupData.ships.size() != 0:
-		var ship = BattlegroupData.ships[BattlegroupData.current_ship]
-		if BattlegroupData.ships[BattlegroupData.current_ship]["option"].size() != 0:
-			var sum = SlotUtils.get_slot_sums(ship)
-			if _src["type"] == Opt.Weapon.SUPERHEAVY and sum["superheavy"] <= 0:
-				_add.hide()
-			elif _src["type"] == Opt.Weapon.PRIMARY and sum["primary"] <= 0:
-				_add.hide()
-			elif _src["type"] == Opt.Weapon.AUXILIARY and sum["auxiliary"] <= 0:
-				_add.hide()
-			if _src in ship["option"]:
-				_remove.show()
-			else:
-				_remove.hide()
-		else:
-			_add.show()
-			_remove.hide()
-	else:
-		_add.show()
-		_remove.hide()
+        _update_buttons()
+
+func _update_buttons() -> void:
+        var show_add := false
+        var show_remove := false
+        if _src.size() != 0 and BattlegroupData.current_ship != -1 and BattlegroupData.ships.size() != 0:
+                var ship = BattlegroupData.ships[BattlegroupData.current_ship]
+                var sum = SlotUtils.get_slot_sums(ship)
+                var used = SlotUtils.get_slot_usage(ship)
+                var key := ""
+                match int(_src.get("type", -1)):
+                        Opt.Weapon.SUPERHEAVY: key = "superheavy"
+                        Opt.Weapon.PRIMARY:    key = "primary"
+                        Opt.Weapon.AUXILIARY:  key = "auxiliary"
+                var capacity := sum.get(key, 0) + int(_src.get("modification", {}).get(key, 0))
+                var points := int(_src.get("points", 0)) + int(_src.get("modification", {}).get("point", 0))
+                show_add = used.get(key, 0) < capacity \
+                        and BattlegroupData.point + points <= 20 \
+                        and not (_has_unique_tag(_src) and _is_unique_taken())
+                show_remove = _count_added(ship) > 0
+        _add.visible = show_add
+        _remove.visible = show_remove
+
+func _has_unique_tag(opt: Dictionary) -> bool:
+        for t in opt.get("tags", "").split(",", false):
+                if t.strip_edges().to_lower() == "уникальное":
+                        return true
+        return false
+
+func _is_unique_taken() -> bool:
+        for s in BattlegroupData.ships:
+                for o in s.get("option", []):
+                        if o.get("name") == _src.get("name"):
+                                return true
+        return false
+
+func _is_same_template(o: Dictionary) -> bool:
+        return o.get("name") == _src.get("name")
+
+func _count_added(ship: Dictionary) -> int:
+        var n := 0
+        for o in ship.get("option", []):
+                if _is_same_template(o):
+                        n += 1
+        return n
 
 
 func populate(weapon):
@@ -60,11 +85,16 @@ func populate(weapon):
 
 
 func _on_add_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(_src)
+        var opt = _src.duplicate(true)
+        BattlegroupData.ships[BattlegroupData.current_ship]["option"].append(opt)
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()
 
 func _on_remove_pressed() -> void:
-        BattlegroupData.ships[BattlegroupData.current_ship]["option"].erase(_src)
+        var arr = BattlegroupData.ships[BattlegroupData.current_ship]["option"]
+        for i in range(arr.size() - 1, -1, -1):
+                if _is_same_template(arr[i]):
+                        arr.remove_at(i)
+                        break
         BattlegroupData.refresh_point()
         BattlegroupData.option_change.emit()


### PR DESCRIPTION
## Summary
- mirror ship add/remove controls for weapon, system, and escort/wing options
- duplicate option resources when adding and remove by template
- ensure options tagged "Уникальное" can be added only once per battlegroup

## Testing
- `godot4 --check --headless` *(fails: command not found)*
- `godot --check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e94d2748320b427561346de9302