### PR TITLE
feat: persist battlegroup data

### DIFF
--- a/Main_scane/Commander/commander.gd
+++ b/Main_scane/Commander/commander.gd
@@ -32,27 +32,34 @@ func refesh_comander():
 
 func _on_name_comander_text_changed(new_text: String) -> void:
 	BattlegroupData.comander["name"] = new_text
+	BattlegroupData.save_data()
 
 
 func _on_positive_1_text_changed(new_text: String) -> void:
 	BattlegroupData.comander["positive_1"] = new_text
+	BattlegroupData.save_data()
 
 
 func _on_positive_2_text_changed(new_text: String) -> void:
 	BattlegroupData.comander["positive_2"] = new_text
+	BattlegroupData.save_data()
 
 
 func _on_negative_text_changed(new_text: String) -> void:
 	BattlegroupData.comander["negative"] = new_text
+	BattlegroupData.save_data()
 
 
 func _on_positive_1_check_box_pressed() -> void:
 	BattlegroupData.comander["positive_1_check"] = _positive1_check.button_pressed
+	BattlegroupData.save_data()
 
 
 func _on_positive_2_check_box_pressed() -> void:
 	BattlegroupData.comander["positive_2_check"] = _positive2_check.button_pressed
+	BattlegroupData.save_data()
 
 
 func _on_negative_check_box_pressed() -> void:
 	BattlegroupData.comander["negative_check"] = _negative_check.button_pressed
+	BattlegroupData.save_data()

--- a/note.gd
+++ b/note.gd
@@ -20,3 +20,4 @@ func _on_visibility_changed() -> void:
 
 func _on_text_edit_text_changed() -> void:
 	BattlegroupData.comander["backstory"] = $TextEdit.text
+	BattlegroupData.save_data()


### PR DESCRIPTION
## Summary
- store battlegroup ships and commander to a save file
- restore saved data on startup
- save commander edits immediately

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c32839588320b274eb55b9eee90e