### PR TITLE
Reset scroll position on option and hull selection

### DIFF
--- a/Main_scane/Hull_list/hulls_list.gd
+++ b/Main_scane/Hull_list/hulls_list.gd
@@ -13,6 +13,7 @@ const Opt = preload("res://option_types.gd")
 @onready var _frigate_count = $Inform_panel/Frigate_container/Label2
 @onready var _carrier_count = $Inform_panel/Carrier_container/Label2
 @onready var _battleship_count = $Inform_panel/Battleship_container/Label2
+@onready var _scroll: ScrollContainer = $Hulls_list
 
 func _ready() -> void:
 	var raw := _load_json(json_path)
@@ -21,6 +22,7 @@ func _ready() -> void:
 
 	for hull_data in raw.get("hulls", []):
 		_spawn_hull(hull_data)
+	visibility_changed.connect(_on_visibility_changed)
 
 func _process(delta: float) -> void:
 	_point.text = str(BattlegroupData.point) + "/20"
@@ -68,6 +70,11 @@ func _on_option_button_item_selected(index: int) -> void:
 		_frigate.show()
 		_carrier.show()
 		_battleship.show()
+	_scroll.scroll_vertical = 0
+
+func _on_visibility_changed() -> void:
+	if visible:
+		_scroll.scroll_vertical = 0
 
 
 func _on_button_pressed() -> void:

--- a/Main_scane/Option_list/option_list.gd
+++ b/Main_scane/Option_list/option_list.gd
@@ -10,6 +10,7 @@ const Opt = preload("res://option_types.gd")
 @export var system_scene   := preload("res://Main_scane/Option_list/system.tscn")
 @export var eswg_scene     := preload("res://Main_scane/Option_list/escort_wing.tscn")
 @onready var _tag_button: OptionButton = $MarginContainer/VBoxContainer/OptionButton2
+@onready var _scroll: ScrollContainer = $MarginContainer/VBoxContainer/ScrollContainer
 var _tag_suffix_re := RegEx.new()
 
 ## ───────────────────────────────────────────────────────────────────
@@ -31,6 +32,7 @@ var _tag_suffix_re := RegEx.new()
 ## ───────────────────────────────────────────────────────────────────
 func _ready() -> void:
 	_tag_suffix_re.compile("\\s*[\\-–+]?\\d+$")
+	visibility_changed.connect(_on_visibility_changed)
 	BattlegroupData.option_change.connect(_install)
 	_populate_all()
 
@@ -153,9 +155,16 @@ func _apply_filters() -> void:
 ## ───────────────────────────────────────────────────────────────────
 func _on_option_button_item_selected(index: int) -> void:
 	_apply_filters()
+	_scroll.scroll_vertical = 0
 
 func _on_option_button2_item_selected(index: int) -> void:
 	_apply_filters()
+	_scroll.scroll_vertical = 0
+
+func _on_visibility_changed() -> void:
+	_apply_filters()
+	if visible:
+		_scroll.scroll_vertical = 0
 
 ## ───────────────────────────────────────────────────────────────────
 ## 6.  JSON utils
@@ -198,9 +207,6 @@ func _populate_tag_button(tag_list: Array) -> void:
 	for t in tag_list:
 		_tag_button.add_item(t)
 
-
-func _on_visibility_changed() -> void:
-	_apply_filters()
 
 func _install():
 	_apply_filters()


### PR DESCRIPTION
## Summary
- reset ScrollContainer to top when changing filters in option list
- reset ScrollContainer to top when changing filters in hull list

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8509b947c832091704dbf52129760