### PR TITLE
Reset filters on OptionButton visibility

### DIFF
--- a/Main_scane/Hull_list/hulls_list.gd
+++ b/Main_scane/Hull_list/hulls_list.gd
@@ -1,8 +1,8 @@
 ###  HullList.gd  ###
 extends VBoxContainer                        # навесьте на узел Hull_list
 
-@export var json_path := "res://battlegroup_data.json"
-@export var hull_scene:= preload("res://support_scanes/hull.tscn")    # drag-and-drop Hull.tscn в инспекторе
+@export var json_path = "res://battlegroup_data.json"
+@export var hull_scene = preload("res://support_scanes/hull.tscn")    # drag-and-drop Hull.tscn в инспекторе
 const Opt = preload("res://option_types.gd")
 
 @onready var _frigate: VBoxContainer = $Hulls_list/VBoxContainer/Frigate
@@ -13,14 +13,17 @@ const Opt = preload("res://option_types.gd")
 @onready var _frigate_count = $Inform_panel/Frigate_container/Label2
 @onready var _carrier_count = $Inform_panel/Carrier_container/Label2
 @onready var _battleship_count = $Inform_panel/Battleship_container/Label2
+@onready var _scroll: ScrollContainer = $Hulls_list
 
 func _ready() -> void:
-	var raw := _load_json(json_path)
+	var raw = _load_json(json_path)
 	if raw.is_empty():
 		return
 
 	for hull_data in raw.get("hulls", []):
 		_spawn_hull(hull_data)
+	visibility_changed.connect(_on_visibility_changed)
+	_options.visibility_changed.connect(_on_options_visibility_changed)
 
 func _process(delta: float) -> void:
 	_point.text = str(BattlegroupData.point) + "/20"
@@ -30,7 +33,7 @@ func _process(delta: float) -> void:
 ### utils -----------------------------------------------------------------
 
 func _spawn_hull(hull_data: Dictionary) -> void:
-	var hull := hull_scene.instantiate()
+	var hull = hull_scene.instantiate()
 	if int(hull_data["class"]) == BattlegroupData.ShipClass.FRIGATE:
 		_frigate.add_child(hull)
 	elif int(hull_data["class"]) == BattlegroupData.ShipClass.CARRIER:
@@ -43,7 +46,7 @@ func _spawn_hull(hull_data: Dictionary) -> void:
 	#_box.add_child(HSeparator.new())
 
 func _load_json(path: String) -> Dictionary:
-	var f := FileAccess.open(path, FileAccess.READ)
+	var f = FileAccess.open(path, FileAccess.READ)
 	if f == null:
 		push_error("Файл %s не найден" % path)
 		return {}
@@ -68,6 +71,17 @@ func _on_option_button_item_selected(index: int) -> void:
 		_frigate.show()
 		_carrier.show()
 		_battleship.show()
+	_scroll.scroll_vertical = 0
+
+func _on_visibility_changed() -> void:
+	if visible:
+		_options.select(Opt.HullFilter.ALL)
+		_on_option_button_item_selected(Opt.HullFilter.ALL)
+
+func _on_options_visibility_changed() -> void:
+	if _options.visible:
+		_options.select(Opt.HullFilter.ALL)
+		_on_option_button_item_selected(Opt.HullFilter.ALL)
 
 
 func _on_button_pressed() -> void:


### PR DESCRIPTION
## Summary
- reset option list category and tag filters to "Все" when lists or buttons reappear
- reset hull list filter to "All" on visibility change and drop deprecated := assignments

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8509b947c832091704dbf52129760