### PR TITLE
Fix variable naming and replace unsupported typed assignments

### DIFF
--- a/Main_scane/Commander/Feat_ship.tscn
+++ b/Main_scane/Commander/Feat_ship.tscn
@@ -91,7 +91,7 @@ mouse_filter = 2
 bbcode_enabled = true
 fit_content = true
 
-[node name="Discription" type="RichTextLabel" parent="Feat/MarginContainer/VBoxContainer"]
+[node name="Description" type="RichTextLabel" parent="Feat/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 bbcode_enabled = true

--- a/Main_scane/Commander/battlegroup.gd
+++ b/Main_scane/Commander/battlegroup.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 
-@export var ship_scene:= preload("res://Main_scane/Commander/ship.tscn") 
+@export var ship_scene = preload("res://Main_scane/Commander/ship.tscn")
 
 
 @onready var _point = $Inform_panel/Point_container/Label2

--- a/Main_scane/Commander/commander.gd
+++ b/Main_scane/Commander/commander.gd
@@ -3,7 +3,7 @@ extends HBoxContainer
 var old_node
 signal change_scene(parent_node)
 
-@onready var _name : LineEdit = $VBoxContainer/NameComander
+@onready var _name : LineEdit = $VBoxContainer/NameCommander
 @onready var _positive1 : LineEdit = $VBoxContainer/HBoxContainer/Positive1
 @onready var _positive2 : LineEdit = $VBoxContainer/HBoxContainer/Positive2
 @onready var _negative : LineEdit = $VBoxContainer/HBoxContainer3/Negative
@@ -13,57 +13,57 @@ signal change_scene(parent_node)
 @onready var _backstory : RichTextLabel = $VBoxContainer/Backstory
 
 func _ready() -> void:
-	refesh_comander()
+        refresh_commander()
 
 
 func _on_button_pressed() -> void:
 	emit_signal("change_scene", _backstory)
 
-func refesh_comander():
-	_name.text = BattlegroupData.comander["name"]
-	$VBoxContainer/Label3.text = BattlegroupData.comander["name"]
-	_positive1.text = BattlegroupData.comander["positive_1"]
-	$VBoxContainer/HBoxContainer/Label3.text = BattlegroupData.comander["positive_1"]
-	_positive2.text = BattlegroupData.comander["positive_2"]
-	$VBoxContainer/HBoxContainer/Label4.text = BattlegroupData.comander["positive_2"]
-	_negative.text = BattlegroupData.comander["negative"]
-	$VBoxContainer/HBoxContainer3/Label4.text = BattlegroupData.comander["negative"]
-	_positive1_check.button_pressed = BattlegroupData.comander["positive_1_check"]
-	_positive2_check.button_pressed = BattlegroupData.comander["positive_2_check"]
-	_negative_check.button_pressed = BattlegroupData.comander["negative_check"]
-	_backstory.text = BattlegroupData.comander["backstory"]
+func refresh_commander():
+        _name.text = BattlegroupData.commander["name"]
+        $VBoxContainer/Label3.text = BattlegroupData.commander["name"]
+        _positive1.text = BattlegroupData.commander["positive_1"]
+        $VBoxContainer/HBoxContainer/Label3.text = BattlegroupData.commander["positive_1"]
+        _positive2.text = BattlegroupData.commander["positive_2"]
+        $VBoxContainer/HBoxContainer/Label4.text = BattlegroupData.commander["positive_2"]
+        _negative.text = BattlegroupData.commander["negative"]
+        $VBoxContainer/HBoxContainer3/Label4.text = BattlegroupData.commander["negative"]
+        _positive1_check.button_pressed = BattlegroupData.commander["positive_1_check"]
+        _positive2_check.button_pressed = BattlegroupData.commander["positive_2_check"]
+        _negative_check.button_pressed = BattlegroupData.commander["negative_check"]
+        _backstory.text = BattlegroupData.commander["backstory"]
 
 
-func _on_name_comander_text_changed(new_text: String) -> void:
-	BattlegroupData.comander["name"] = new_text
+func _on_name_commander_text_changed(new_text: String) -> void:
+        BattlegroupData.commander["name"] = new_text
 	BattlegroupData.save_data()
 
 
 func _on_positive_1_text_changed(new_text: String) -> void:
-	BattlegroupData.comander["positive_1"] = new_text
+        BattlegroupData.commander["positive_1"] = new_text
 	BattlegroupData.save_data()
 
 
 func _on_positive_2_text_changed(new_text: String) -> void:
-	BattlegroupData.comander["positive_2"] = new_text
+        BattlegroupData.commander["positive_2"] = new_text
 	BattlegroupData.save_data()
 
 
 func _on_negative_text_changed(new_text: String) -> void:
-	BattlegroupData.comander["negative"] = new_text
+        BattlegroupData.commander["negative"] = new_text
 	BattlegroupData.save_data()
 
 
 func _on_positive_1_check_box_pressed() -> void:
-	BattlegroupData.comander["positive_1_check"] = _positive1_check.button_pressed
+        BattlegroupData.commander["positive_1_check"] = _positive1_check.button_pressed
 	BattlegroupData.save_data()
 
 
 func _on_positive_2_check_box_pressed() -> void:
-	BattlegroupData.comander["positive_2_check"] = _positive2_check.button_pressed
+        BattlegroupData.commander["positive_2_check"] = _positive2_check.button_pressed
 	BattlegroupData.save_data()
 
 
 func _on_negative_check_box_pressed() -> void:
-	BattlegroupData.comander["negative_check"] = _negative_check.button_pressed
+        BattlegroupData.commander["negative_check"] = _negative_check.button_pressed
 	BattlegroupData.save_data()

--- a/Main_scane/Commander/commander.tscn
+++ b/Main_scane/Commander/commander.tscn
@@ -45,7 +45,7 @@ grow_vertical = 2
 mouse_filter = 1
 flat = true
 
-[node name="NameComander" type="LineEdit" parent="VBoxContainer"]
+[node name="NameCommander" type="LineEdit" parent="VBoxContainer"]
 visible = false
 layout_mode = 2
 mouse_filter = 1
@@ -176,10 +176,10 @@ mouse_filter = 1
 text = "Редактировать предысторию"
 
 [connection signal="pressed" from="VBoxContainer/Label3/Button" to="VBoxContainer" method="_on_button_pressed"]
-[connection signal="focus_exited" from="VBoxContainer/NameComander" to="VBoxContainer" method="_on_NameComander_focus_exited"]
-[connection signal="mouse_exited" from="VBoxContainer/NameComander" to="VBoxContainer" method="_on_NameComander_mouse_exited"]
-[connection signal="text_changed" from="VBoxContainer/NameComander" to="." method="_on_name_comander_text_changed"]
-[connection signal="text_submitted" from="VBoxContainer/NameComander" to="VBoxContainer" method="_on_NameComander_text_submitted"]
+[connection signal="focus_exited" from="VBoxContainer/NameCommander" to="VBoxContainer" method="_on_NameCommander_focus_exited"]
+[connection signal="mouse_exited" from="VBoxContainer/NameCommander" to="VBoxContainer" method="_on_NameCommander_mouse_exited"]
+[connection signal="text_changed" from="VBoxContainer/NameCommander" to="." method="_on_name_commander_text_changed"]
+[connection signal="text_submitted" from="VBoxContainer/NameCommander" to="VBoxContainer" method="_on_NameCommander_text_submitted"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Positive1CheckBox" to="." method="_on_positive_1_check_box_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Label3/Button" to="VBoxContainer/HBoxContainer/Label3" method="_on_button_pressed"]
 [connection signal="focus_exited" from="VBoxContainer/HBoxContainer/Positive1" to="VBoxContainer/HBoxContainer/Label3" method="_on_name_focus_exited"]

--- a/Main_scane/Commander/feat_ship.gd
+++ b/Main_scane/Commander/feat_ship.gd
@@ -21,7 +21,7 @@ const Opt                  = preload("res://option_types.gd")
 @onready var _tenacity    : Label           = $Feat/Header/MarginContainer/Header/Damage_range_container/Tenacity
 @onready var _hp          : Label           = $Feat/Header/MarginContainer/Header/Damage_range_container/HP
 @onready var _effect      : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Effect
-@onready var _discription : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Discription
+@onready var _description : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Description
 @onready var _header      : PanelContainer  = $Feat/Header
 @onready var _hide_btn    : Button          = $Feat/Header/MarginContainer/Header/Hide
 @onready var _remove_btn  : Button          = $Feat/MarginContainer/VBoxContainer/HBoxContainer/Remove
@@ -56,9 +56,9 @@ func set_context(removable: bool, host_ship: Dictionary, is_option_item: bool=fa
 	_update_remove_visibility()
 
 func _update_remove_visibility() -> void:
-	var t := int(_data.get("type", -999))
+	var t = int(_data.get("type", -999))
 	# Прятать Remove только для option-элементов, если это слоты 7/8 (Тактика/Манёвр как опция)
-	var is_tactic_or_maneuver_option := _is_option_item and (t == 7 or t == 8)
+	var is_tactic_or_maneuver_option = _is_option_item and (t == 7 or t == 8)
 	_remove_btn.visible = _removable and not is_tactic_or_maneuver_option and not _data.get("name") == "FLAGSHIP"
 
 func _on_hide_pressed() -> void:
@@ -70,8 +70,8 @@ func _on_remove_pressed() -> void:
 	if not _removable or _host_ship.is_empty():
 		return
 	
-	var removed := false
-	var removed_from := ""  # "special" | "option" (для логики отката бонусов)
+	var removed = false
+	var removed_from = ""  # "special" | "option" (для логики отката бонусов)
 
 	# Если эта карточка — ПОСЛЕДНЯЯ в своём контейнере, сперва пробуем удалить из special
 	if _is_last_in_parent() and _host_ship.has("special") and (_host_ship["special"] is Array):
@@ -93,7 +93,7 @@ func _on_remove_pressed() -> void:
 	_apply_on_remove_effects(_data.get("name", ""))
 	remove_overflow_by_sum()
 	# Обновляем UI/счётчики
-	var root := get_parent()
+	var root = get_parent()
 	if root and root.get_parent() and root.get_parent().get_parent() and root.get_parent().get_parent().get_parent():
 		root.get_parent().get_parent().get_parent()._refresh_option_buttons()
 
@@ -116,14 +116,14 @@ func set_context_for_option(ship_ref: Dictionary, option_ref: Dictionary) -> voi
 		_remove_btn.visible = true
 
 func _is_last_in_parent() -> bool:
-	var p := get_parent()
+	var p = get_parent()
 	if p == null:
 		return false
 	return p.get_child_count() > 0 and p.get_child(p.get_child_count() - 1) == self
 
 func _remove_from_array_by_template(arr: Array) -> bool:
 	# Пытаемся по точной ссылке
-	var idx := arr.find(_data)
+	var idx = arr.find(_data)
 	# Если не нашли — по имени (шаблонному совпадению)
 	if idx == -1:
 		for i in range(arr.size() - 1, -1, -1):
@@ -159,14 +159,14 @@ func _dec_support_slot(which: String, by: int) -> void:
 	if not _host_ship.has("support_slots"):
 		return
 	var ss = _host_ship.get("support_slots", {})
-	var cur := _to_int(ss.get(which, "0"))
+	var cur = _to_int(ss.get(which, "0"))
 	cur = max(cur - by, 0)
 	ss[which] = str(cur)
 	_host_ship["support_slots"] = ss
 
 func _dec_hp(by: int) -> void:
 	# HP не должен опуститься ниже 1 (страховка)
-	var cur_hp := _to_int(_host_ship.get("hp", "0"))
+	var cur_hp = _to_int(_host_ship.get("hp", "0"))
 	cur_hp = max(cur_hp - by, 1)
 	_host_ship["hp"] = str(cur_hp)
 
@@ -177,7 +177,7 @@ func _to_int(v) -> int:
 		TYPE_FLOAT:
 			return int(round(v))
 		TYPE_STRING:
-			var s := String(v).strip_edges()
+			var s = String(v).strip_edges()
 			if s == "":
 				return 0
 			return int(s)
@@ -231,12 +231,12 @@ func populate(data: Dictionary) -> void:
 	if str(data.get("hp", "")).strip_edges() != "":
 		_hp.text = "[HP %s]" % data.get("hp")
 
-	_effect.text = data.get("effect", "")
-	_discription.text = "[i]" + data.get("discription", "")
+		_effect.text = data.get("effect", "")
+		_description.text = "[i]" + data.get("discription", "")
 
-	_hide_if_text_empty(self)
-	_change_theme()
-	_update_remove_visibility()
+		_hide_if_text_empty(self)
+		_change_theme()
+		_update_remove_visibility()
 
 
 func remove_overflow_by_sum() -> bool:
@@ -244,10 +244,10 @@ func remove_overflow_by_sum() -> bool:
 	if opts.is_empty():
 		return false
 
-	var changed := false
+	var changed = false
 
 	# Берём суммы (должны содержать "wings" и "escorts")
-	var sums := SlotUtils.get_slot_sums(_host_ship)
+	var sums = SlotUtils.get_slot_sums(_host_ship)
 
 	# Если крыльев больше лимита → по одному снимаем последние, пока не станет неотрицательно
 	while sums.get("wing") < 0:
@@ -276,7 +276,7 @@ func remove_overflow_by_sum() -> bool:
 # Хелпер: удалить ПОСЛЕДНЮЮ опцию, у которой type совпадает с любым из types_to_match
 func _remove_last_by_types(arr: Array, types_to_match: Array) -> bool:
 	for i in range(arr.size() - 1, -1, -1):
-		var t := int(arr[i].get("type", -999))
+		var t = int(arr[i].get("type", -999))
 		if t in types_to_match:
 			arr.remove_at(i)
 			return true

--- a/Main_scane/Commander/option_ship.gd
+++ b/Main_scane/Commander/option_ship.gd
@@ -2,7 +2,7 @@ extends GridContainer
 
 const SlotUtils = preload("res://slot_utils.gd")
 
-@onready var _labels := {
+@onready var _labels = {
 	"superheavy": $Superheavies/Superheavy,
 	"primaries": $Primaries/Primary,
 	"auxiliaries": $Auxiliaries/Auxiliary,
@@ -32,7 +32,7 @@ func _update_from_ship() -> void:
 		_refresh_visibility()
 
 func _refresh_visibility() -> void:
-	var any_visible := false
+        var any_visible = false
 	for c in get_children():
 		if c.get_child(1).text != "0/0":
 			c.visible = true

--- a/Main_scane/Commander/ship.gd
+++ b/Main_scane/Commander/ship.gd
@@ -1,7 +1,7 @@
 extends PanelContainer
 # class_name ShipCard
 
-const FLAGSHIP_OPTION := {
+const FLAGSHIP_OPTION =  {
 	"description":  "",
 	"effect":       "",
 	"feats":        [],
@@ -43,7 +43,7 @@ const Opt                  = preload("res://option_types.gd")
 @onready var _def_lbl     : Label         = $Ship_box/VBoxContainer/Atributs/Defence/Defence
 
 # Контейнеры слотов для опций
-@onready var _slot_containers := {
+@onready var _slot_containers =  {
 	0.0: $Ship_box/VBoxContainer/Superheavy,   # Superheavy
 	1.0: $Ship_box/VBoxContainer/Primary,      # Primaries
 	2.0: $Ship_box/VBoxContainer/Auxiliary,    # Auxiliaries
@@ -77,12 +77,12 @@ func _ready() -> void:
 # ───────────────────────────────────────────
 
 func _inc_hp(by: int) -> void:
-	var hp := _to_int(ship_cur.get("hp", 0)) + by
+	var hp =  _to_int(ship_cur.get("hp", 0)) + by
 	ship_cur["hp"] = str(max(hp, 1))  # защита от нуля
 
 func _inc_system_slots(by: int) -> void:
 	var ss = ship_cur.get("support_slots", {})
-	var cur := _to_int(ss.get("systems", 0)) + by
+	var cur =  _to_int(ss.get("systems", 0)) + by
 	ss["systems"] = str(max(cur, 0))
 	ship_cur["support_slots"] = ss
 
@@ -152,7 +152,7 @@ func _on_flagman_toggled(on : bool) -> void:
 		_refresh_option_buttons()
 	else:
 		# Снимаем только если FLAGSHIP действительно стоит на ЭТОМ корабле
-		var idx := _has_flagship_option()
+		var idx =  _has_flagship_option()
 		if idx != -1:
 			ship["option"].remove_at(idx)
 			_inc_system_slots(-1)  # -1 слот систем
@@ -168,8 +168,8 @@ func _on_option_pressed() -> void:
 	BattlegroupData.change_on_option()
 
 func _on_delete_pressed() -> void:
-	var cls := int(ship_cur.get("class", -1))
-	var idx := BattlegroupData.ships.find(ship_cur)
+	var cls =  int(ship_cur.get("class", -1))
+	var idx =  BattlegroupData.ships.find(ship_cur)
 	if idx == -1:
 		return
 
@@ -206,9 +206,9 @@ func _clear_containers_keep_titles() -> void:
 			n.queue_free()
 
 func _add_button_with_card(to_container: VBoxContainer, data: Dictionary, removable: bool) -> void:
-	var btn := Button.new()
-	var marg := MarginContainer.new()
-	var panel := PanelContainer.new()
+	var btn =  Button.new()
+	var marg =  MarginContainer.new()
+	var panel =  PanelContainer.new()
 	panel.add_child(marg)
 	marg.add_child(btn)
 	to_container.add_child(panel)
@@ -235,13 +235,13 @@ func _add_button_with_card(to_container: VBoxContainer, data: Dictionary, remova
 	)
 
 func _add_button_with_card_special(to_container: VBoxContainer, data: Dictionary, removable: bool) -> void:
-	var btn := Button.new()
+	var btn =  Button.new()
 	btn.mouse_filter = Control.MOUSE_FILTER_PASS
 	btn.flat = true
 	btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
 	btn.theme = hide_theme
-	var marg := MarginContainer.new()
-	var panel := PanelContainer.new()
+	var marg =  MarginContainer.new()
+	var panel =  PanelContainer.new()
 	marg.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	btn.text = str(data.get("name", ""))
@@ -327,9 +327,9 @@ func _refresh_option_buttons() -> void:
 # 6.  Пересчёт характеристик + рендер
 # ───────────────────────────────────────────
 func _recalc_and_update_display() -> void:
-	var hp      := int(ship_cur["hp"])
-	var defence := int(ship_cur["defense"])
-	var points  := int(ship_cur["points"])
+	var hp      =  int(ship_cur["hp"])
+	var defence =  int(ship_cur["defense"])
+	var points  =  int(ship_cur["points"])
 
 	var weapon  = ship_cur["weapon_slots"].duplicate()
 	var support = ship_cur["support_slots"].duplicate()
@@ -382,10 +382,10 @@ func _is_apeiron() -> bool:
 func _range_plus_one_capped(r: String) -> String:
 	if r == null:
 		return ""
-	var s := String(r).strip_edges().replace("–", "-")  # на случай en dash
+	var s =  String(r).strip_edges().replace("–", "-")  # на случай en dash
 	if s == "" or (not s[0].is_valid_int() and "-" not in s):
 		return s
-	var parts := s.split("-")
+	var parts =  s.split("-")
 	if parts.size() == 1:
 		var a = clamp(_to_int(parts[0]) + 1, 0, 5)
 		return str(a)
@@ -397,18 +397,18 @@ func _range_plus_one_capped(r: String) -> String:
 func _range_in_text_plus_one_capped(text: String) -> String:
 	if text == null:
 		return ""
-	var s := String(text)
-	var re := RegEx.new()
+	var s =  String(text)
+	var re =  RegEx.new()
 	# Матчим одиночные/двузначные числа по обе стороны дефиса/эн-даша, но не как часть других чисел/слов.
 	re.compile(r"(?<!\d)(\d+)\s*(?:-|–)\s*(\d+)(?!\d)")
-	var matches := re.search_all(s)
+	var matches =  re.search_all(s)
 	if matches == null or matches.is_empty():
 		return s
-	var out := ""
-	var pos := 0
+	var out =  ""
+	var pos =  0
 	for m in matches:
-		var a_str := m.get_string(1)
-		var b_str := m.get_string(2)
+		var a_str =  m.get_string(1)
+		var b_str =  m.get_string(2)
 		var a = clamp(_to_int(a_str) + 1, 0, 5)
 		var b = clamp(_to_int(b_str) + 1, 0, 5)
 		out += s.substr(pos, m.get_start() - pos)
@@ -434,18 +434,18 @@ func _apply_range_bonus_in_dict(d: Dictionary) -> void:
 					_apply_range_bonus_in_dict(i)
 
 func _apply_range_bonus_if_wing(data: Dictionary) -> Dictionary:
-	var copy := data.duplicate(true)
+	var copy =  data.duplicate(true)
 	_apply_range_bonus_in_dict(copy)
 	return copy
 
 func _to_int(v) -> int:
-	var t := typeof(v)
+	var t =  typeof(v)
 	if t == TYPE_INT:
 		return v
 	if t == TYPE_FLOAT:
 		return int(round(v))
 	if t == TYPE_STRING:
-		var s := String(v).strip_edges()
+		var s =  String(v).strip_edges()
 		if s == "":
 			return 0
 		if s.is_valid_int():
@@ -457,14 +457,14 @@ func _to_int(v) -> int:
 
 func _dec_support_slot(slot_key: String, by: int) -> void:
 	var ss = ship_cur.get("support_slots", {})
-	var cur := _to_int(ss.get(slot_key, 0))
+	var cur =  _to_int(ss.get(slot_key, 0))
 	ss[slot_key] = str(max(cur - by, 0))
 	ship_cur["support_slots"] = ss
 
 # удалить ПОСЛЕДНИЙ элемент нужного типа и вернуть его ({} если не найден)
 func _remove_last_and_get(arr: Array, types_to_match: Array) -> Dictionary:
 	for i in range(arr.size() - 1, -1, -1):
-		var t := int(arr[i].get("type", -999))
+		var t =  int(arr[i].get("type", -999))
 		if t in types_to_match:
 			var removed = arr[i]
 			arr.remove_at(i)
@@ -474,7 +474,7 @@ func _remove_last_and_get(arr: Array, types_to_match: Array) -> Dictionary:
 # оставить, если где-то ещё используется
 func _remove_last_by_types(arr: Array, types_to_match: Array) -> bool:
 	for i in range(arr.size() - 1, -1, -1):
-		var t := int(arr[i].get("type", -999))
+		var t =  int(arr[i].get("type", -999))
 		if t in types_to_match:
 			arr.remove_at(i)
 			return true
@@ -491,22 +491,22 @@ func remove_overflow_by_sum() -> bool:
 	if opts.is_empty():
 		return false
 
-	var changed := false
-	var guard := 0
+	var changed =  false
+	var guard =  0
 
 	while true:
 		guard += 1
 		if guard > 64:
 			break
 
-		var sums := SlotUtils.get_slot_sums(ship_cur)
-		var wing_sum   := _to_int(sums.get("wing",   0))
-		var escort_sum := _to_int(sums.get("escort", 0))
-		var system_sum := _to_int(sums.get("system", 0))
+		var sums =  SlotUtils.get_slot_sums(ship_cur)
+		var wing_sum   =  _to_int(sums.get("wing",   0))
+		var escort_sum =  _to_int(sums.get("escort", 0))
+		var system_sum =  _to_int(sums.get("system", 0))
 
 		# 1) Крылья
 		if wing_sum < 0:
-			var rem_w := _remove_last_and_get(opts, [Opt.Support.WING, Opt.SlotIndex.WINGS])
+			var rem_w =  _remove_last_and_get(opts, [Opt.Support.WING, Opt.SlotIndex.WINGS])
 			if rem_w.size() == 0:
 				break
 			changed = true
@@ -515,7 +515,7 @@ func remove_overflow_by_sum() -> bool:
 
 		# 2) Эскорты
 		if escort_sum < 0:
-			var rem_e := _remove_last_and_get(opts, [Opt.Support.ESCORT, Opt.SlotIndex.ESCORTS])
+			var rem_e =  _remove_last_and_get(opts, [Opt.Support.ESCORT, Opt.SlotIndex.ESCORTS])
 			if rem_e.size() == 0:
 				break
 			changed = true
@@ -524,12 +524,12 @@ func remove_overflow_by_sum() -> bool:
 
 		# 3) Системы
 		if system_sum < 0:
-			var rem_s := _remove_last_and_get(opts, [Opt.SlotIndex.SYSTEMS])
+			var rem_s =  _remove_last_and_get(opts, [Opt.SlotIndex.SYSTEMS])
 			if rem_s.size() == 0:
 				break
 			changed = true
 
-			var rname := String(rem_s.get("name", ""))
+			var rname =  String(rem_s.get("name", ""))
 			# если сняли систему, которая добавляла кап — срежем его тоже
 			if rname == "SUBLINE BERTH":
 				_dec_support_slot("escorts", 1)

--- a/Main_scane/Commander/v_box_container.gd
+++ b/Main_scane/Commander/v_box_container.gd
@@ -1,18 +1,18 @@
 extends VBoxContainer
 # Godot 4.x
 
-@export var update_interval := 0.2   # как часто пересчитывать (в секундах)
+@export var update_interval = 0.2   # как часто пересчитывать (в секундах)
 @onready var _label: Label = $Label2
 
-const NAME_FLAGSHIP     := "FLAGSHIP"
-const NAME_SANDSTORM    := "SANDSTORM"
-const NAME_LOUIS_XIV    := "LOUIS XIV"
-const NAME_FIGHTER_WING := "FIGHTER WING"
-const TYPE_WING         := 4
+const NAME_FLAGSHIP     = "FLAGSHIP"
+const NAME_SANDSTORM    = "SANDSTORM"
+const NAME_LOUIS_XIV    = "LOUIS XIV"
+const NAME_FIGHTER_WING = "FIGHTER WING"
+const TYPE_WING         = 4
 
-var _accum := 0.0
-var _last_text := ""
-var _last_tooltip := ""
+var _accum = 0.0
+var _last_text = ""
+var _last_tooltip = ""
 
 func _ready() -> void:
 	set_process(true)
@@ -34,9 +34,9 @@ func _recompute(force: bool = false) -> void:
 
 	var ships: Array = bd.ships
 
-	var d6 := 0
-	var flat := 0
-	var src_count := {
+        var d6 = 0
+        var flat = 0
+        var src_count = {
 		"FLAGSHIP_d6": 0,
 		"LOUIS_XIV_d6": 0,
 		"FIGHTER_WING_flat": 0,
@@ -44,7 +44,7 @@ func _recompute(force: bool = false) -> void:
 	}
 
 	for ship in ships:
-		var sname := _canon_name(ship.get("name", ""))
+                var sname = _canon_name(ship.get("name", ""))
 
 		# HA LOUIS XIV–CLASS DREADNOUGHT → +1d6 за каждый
 		if sname.find(NAME_LOUIS_XIV) != -1:
@@ -53,8 +53,8 @@ func _recompute(force: bool = false) -> void:
 
 		# Опции/прикреплённые элементы к корпусу
 		for opt in ship.get("option", []):
-			var oname := _canon_name(opt.get("name", ""))
-			var otype := int(opt.get("type", -1))
+                        var oname = _canon_name(opt.get("name", ""))
+                        var otype = int(opt.get("type", -1))
 
 			# FLAGSHIP как опция
 			if oname.find(NAME_FLAGSHIP) != -1:
@@ -81,7 +81,7 @@ func _recompute(force: bool = false) -> void:
 	flat += fw_bonus
 
 	# Собираем текст в стиле 2d6+6
-	var text := ""
+        var text = ""
 	if d6 > 0 and flat != 0:
 		text = "%dd6%+d" % [d6, flat]
 	elif d6 > 0:
@@ -92,7 +92,7 @@ func _recompute(force: bool = false) -> void:
 		text = "0"
 
 	# Обновляем лейбл только если что-то реально поменялось
-	var tooltip := _build_tooltip(src_count, d6, flat)
+        var tooltip = _build_tooltip(src_count, d6, flat)
 	if _label and (text != _last_text or tooltip != _last_tooltip or force):
 		_last_text = text
 		_last_tooltip = tooltip
@@ -103,7 +103,7 @@ func _canon_name(raw: String) -> String:
 	return raw.replace("\n", " ").to_upper()
 
 func _build_tooltip(src: Dictionary, d6: int, flat: int) -> String:
-	var sum_line := ""
+        var sum_line = ""
 	if d6 > 0 and flat != 0:
 		sum_line = "%dd6 %+d" % [d6, flat]
 	elif d6 > 0:

--- a/Main_scane/Commander/v_box_container1.gd
+++ b/Main_scane/Commander/v_box_container1.gd
@@ -6,27 +6,27 @@ func _process(delta: float) -> void:
 
 func _on_button_pressed() -> void:
 	if $Label3.text == "Имя персонажа":
-		$NameComander.text = ""
+                $NameCommander.text = ""
 	else :
-		$NameComander.text = $Label3.text
-	$NameComander.show()
-	$NameComander.grab_focus()
-	$NameComander.set_caret_column($NameComander.text.length())
+                $NameCommander.text = $Label3.text
+        $NameCommander.show()
+        $NameCommander.grab_focus()
+        $NameCommander.set_caret_column($NameCommander.text.length())
 	$Label3.hide()
 
-func _on_NameComander_text_submitted(new_text: String) -> void:
-	$Label3.text = $NameComander.text
-	$NameComander.hide()
+func _on_NameCommander_text_submitted(new_text: String) -> void:
+        $Label3.text = $NameCommander.text
+        $NameCommander.hide()
 	$Label3.show()
 
 
-func _on_NameComander_focus_exited() -> void:
-	$Label3.text = $NameComander.text
-	$NameComander.hide()
+func _on_NameCommander_focus_exited() -> void:
+        $Label3.text = $NameCommander.text
+        $NameCommander.hide()
 	$Label3.show()
 
 
-func _on_NameComander_mouse_exited() -> void:
-	$Label3.text = $NameComander.text
-	$NameComander.hide()
+func _on_NameCommander_mouse_exited() -> void:
+        $Label3.text = $NameCommander.text
+        $NameCommander.hide()
 	$Label3.show()

--- a/Main_scane/Hull_list/Feat_for_showing.tscn
+++ b/Main_scane/Hull_list/Feat_for_showing.tscn
@@ -81,7 +81,7 @@ mouse_filter = 2
 bbcode_enabled = true
 fit_content = true
 
-[node name="Discription" type="RichTextLabel" parent="Feat/MarginContainer/VBoxContainer"]
+[node name="Description" type="RichTextLabel" parent="Feat/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 bbcode_enabled = true

--- a/Main_scane/Hull_list/feat_for_showing.gd
+++ b/Main_scane/Hull_list/feat_for_showing.gd
@@ -7,7 +7,7 @@ extends PanelContainer
 @onready var _damage      : Label           = $Feat/Header/MarginContainer/Header/Damage_range_container/Damage
 @onready var _range       : Label           = $Feat/Header/MarginContainer/Header/Damage_range_container/Range
 @onready var _effect      : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Effect
-@onready var _discription : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Discription
+@onready var _description : RichTextLabel   = $Feat/MarginContainer/VBoxContainer/Description
 @onready var _header      : PanelContainer  = $Feat/Header
 
 # --- темы ---------------------------------------------------
@@ -51,8 +51,8 @@ func populate(data) -> void:
 		_damage.text = "[Урон %s]" % data.get("damage")
 	if data.get("range") != "":
 		_range.text = "[Дистанция %s]" % data.get("range")
-	_effect.text = data.get("effect")
-	_discription.text = data.get("discription")
+        _effect.text = data.get("effect")
+        _description.text = data.get("discription")
 	_change_theme()
 	_hide_if_text_empty(self)
 

--- a/Main_scane/Option_list/escort_wing.gd
+++ b/Main_scane/Option_list/escort_wing.gd
@@ -7,7 +7,7 @@ const Opt = preload("res://option_types.gd")
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
 @onready var _effect: RichTextLabel = $VBoxContainer/Effect/Effect
-@onready var _discription: RichTextLabel = $VBoxContainer/Discription/Discription
+@onready var _description: RichTextLabel = $VBoxContainer/Description/Description
 @onready var _tactic1: MarginContainer = $VBoxContainer/Tactic1
 @onready var _tactic1_name: RichTextLabel = $VBoxContainer/Tactic1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
 @onready var _tactic1_tag: RichTextLabel = $VBoxContainer/Tactic1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
@@ -18,10 +18,10 @@ const Opt = preload("res://option_types.gd")
 @onready var _tactic2_tag: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
 @onready var _tactic2_range: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label3
 @onready var _tactic2_effect: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
-@onready var _maneveue1: MarginContainer = $VBoxContainer/Maneveue1
-@onready var _maneveue1_name: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
-@onready var _maneveue1_tag: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
-@onready var _maneveue1_effect: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
+@onready var _maneuver1: MarginContainer = $VBoxContainer/Maneuver1
+@onready var _maneuver1_name: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
+@onready var _maneuver1_tag: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
+@onready var _maneuver1_effect: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _add_special: MarginContainer = $VBoxContainer/Button3
 @onready var _remove_special: MarginContainer = $VBoxContainer/Button4
@@ -57,7 +57,7 @@ func _update_buttons() -> void:
 
 			# ----- SPECIAL UI (ветка: опции НЕ пустые) -----
 			var special_arr = ship.get("special", [])
-			var in_special := false
+			var in_special =  false
 			for o in special_arr:
 				if _is_same_template(o):
 					in_special = true
@@ -96,7 +96,7 @@ func _update_buttons() -> void:
 
 			# ----- SPECIAL UI (ветка: опции пустые) -----
 			var special_arr2 = ship.get("special", [])
-			var in_special2 := false
+			var in_special2 =  false
 			for o in special_arr2:
 				if _is_same_template(o):
 					in_special2 = true
@@ -154,7 +154,7 @@ func _is_same_template(o: Dictionary) -> bool:
 		return o.get("name") == _src.get("name")
 
 func _count_added(ship: Dictionary) -> int:
-		var n := 0
+		var n =  0
 		for o in ship.get("option", []):
 				if _is_same_template(o):
 						n += 1
@@ -176,7 +176,7 @@ func populate(system):
 		_param.text += "[Упорство " + system.get("tenacity") + "] "
 	_param.text += "[Очки " + str(int(system.get("points"))) + "]"
 	_effect.text = system.get("effect")
-	_discription.text = "[i]" + system.get("discription") + "[/i]"
+    _description.text = "[i]" + system.get("discription") + "[/i]"
 	if system.get("feats").size() > 0:
 		var feat1 = system.get("feats").get(0)
 		if feat1.get("type") == Opt.FEAT_TACTIC:
@@ -187,10 +187,10 @@ func populate(system):
 				_tactic1_range.text = "[Дистанция %s]" % feat1.get("range")
 			_tactic1_effect.text = feat1.get("effect")
 		else:
-			_maneveue1.visible = true
-			_maneveue1_name.text = feat1.get("name")
-			_maneveue1_tag.text = feat1.get("tags")
-			_maneveue1_effect.text = feat1.get("effect")
+                    _maneuver1.visible = true
+                    _maneuver1_name.text = feat1.get("name")
+                    _maneuver1_tag.text = feat1.get("tags")
+                    _maneuver1_effect.text = feat1.get("effect")
 	if system.get("feats").size() > 1:
 		var feat1 = system.get("feats").get(1)
 		if feat1.get("type") == Opt.FEAT_TACTIC:
@@ -201,10 +201,10 @@ func populate(system):
 				_tactic2_range.text = "[Дистанция %s]" % feat1.get("range")
 			_tactic2_effect.text = feat1.get("effect")
 		else:
-			_maneveue1.visible = true
-			_maneveue1_name.text = feat1.get("name")
-			_maneveue1_tag.text = feat1.get("tags")
-			_maneveue1_effect.text = feat1.get("effect")
+                    _maneuver1.visible = true
+                    _maneuver1_name.text = feat1.get("name")
+                    _maneuver1_tag.text = feat1.get("tags")
+                    _maneuver1_effect.text = feat1.get("effect")
 
 func _on_add_pressed() -> void:
 		var opt = _src.duplicate(true)
@@ -232,7 +232,7 @@ func _on_add_special_pressed() -> void:
 		if _is_same_template(o):
 			return
 
-	var opt := _src.duplicate(true)
+	var opt =  _src.duplicate(true)
 	ship["special"].append(opt)
 
 	# Обновляем UI: у тебя _process → _update_buttons() всё равно перерисует,

--- a/Main_scane/Option_list/escort_wing.tscn
+++ b/Main_scane/Option_list/escort_wing.tscn
@@ -70,59 +70,59 @@ fit_content = true
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="MarginContainer" parent="VBoxContainer"]
+[node name="Description" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="RichTextLabel" parent="VBoxContainer/Discription"]
+[node name="Description" type="RichTextLabel" parent="VBoxContainer/Description"]
 layout_mode = 2
 mouse_filter = 2
 bbcode_enabled = true
 text = "[i]Большое описание Большое описание Большое описание "
 fit_content = true
 
-[node name="Maneveue1" type="MarginContainer" parent="VBoxContainer"]
+[node name="Maneuver1" type="MarginContainer" parent="VBoxContainer"]
 visible = false
 layout_mode = 2
 mouse_filter = 2
 theme = ExtResource("3_ylkxv")
 
-[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer/Maneveue1"]
+[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer/Maneuver1"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneveue1/PanelContainer2"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneuver1/PanelContainer2"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 theme = ExtResource("4_sujst")
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-mouse_filter = 2
-fit_content = true
-
-[node name="Label2" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="Label" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 fit_content = true
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer"]
+[node name="Label2" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+mouse_filter = 2
+fit_content = true
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/MarginContainer"]
+[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/MarginContainer"]
 layout_mode = 2
 mouse_filter = 2
 text = "Описание"

--- a/Main_scane/Option_list/system.gd
+++ b/Main_scane/Option_list/system.gd
@@ -7,7 +7,7 @@ const Opt = preload("res://option_types.gd")
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
 @onready var _effect: RichTextLabel = $VBoxContainer/Effect/Effect
-@onready var _discription: RichTextLabel = $VBoxContainer/Discription/Discription
+@onready var _description: RichTextLabel = $VBoxContainer/Description/Description
 @onready var _tactic1: MarginContainer = $VBoxContainer/Tactic1
 @onready var _tactic1_name: RichTextLabel = $VBoxContainer/Tactic1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
 @onready var _tactic1_tag: RichTextLabel = $VBoxContainer/Tactic1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
@@ -17,10 +17,10 @@ const Opt = preload("res://option_types.gd")
 @onready var _tactic2_name: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
 @onready var _tactic2_tag: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
 @onready var _tactic2_effect: RichTextLabel = $VBoxContainer/Tactic2/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
-@onready var _maneveue1: MarginContainer = $VBoxContainer/Maneveue1
-@onready var _maneveue1_name: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
-@onready var _maneveue1_tag: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
-@onready var _maneveue1_effect: RichTextLabel = $VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
+@onready var _maneuver1: MarginContainer = $VBoxContainer/Maneuver1
+@onready var _maneuver1_name: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label
+@onready var _maneuver1_tag: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/Label2
+@onready var _maneuver1_effect: RichTextLabel = $VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/MarginContainer/RichTextLabel
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _remove: MarginContainer = $VBoxContainer/Button2
 @onready var _add_special:    MarginContainer = $VBoxContainer/Button3
@@ -39,7 +39,7 @@ func _to_int(v) -> int:
 
 func _apply_option_side_effects(ship: Dictionary, opt: Dictionary, delta: int) -> void:
 	# delta: +1 при установке, -1 при демонтаже
-	var name := str(opt.get("name", ""))
+	var name =  str(opt.get("name", ""))
 
 	# безопасно достаём вложенные словари
 	if not ship.has("support_slots") or ship.get("support_slots") == null:
@@ -49,17 +49,17 @@ func _apply_option_side_effects(ship: Dictionary, opt: Dictionary, delta: int) -
 
 	# 1) FIGHTER LAUNCH CATAPULTS → +1 слот крыльев
 	if name == "FIGHTER LAUNCH CATAPULTS":
-		var wings := _to_int(ship["support_slots"].get("wings", 0)) + delta
+		var wings =  _to_int(ship["support_slots"].get("wings", 0)) + delta
 		ship["support_slots"]["wings"] = str(max(wings, 0))
 
 	# 2) SUBLINE BERTH → +1 слот эскортов
 	elif name == "SUBLINE BERTH":
-		var escorts := _to_int(ship["support_slots"].get("escorts", 0)) + delta
+		var escorts =  _to_int(ship["support_slots"].get("escorts", 0)) + delta
 		ship["support_slots"]["escorts"] = str(max(escorts, 0))
 
 	# 3) BULWARK REDUNDANCIES → +3 HP
 	elif name == "BULWARK REDUNDANCIES":
-		var hp := _to_int(ship.get("hp", 0)) + (3 * delta)
+		var hp =  _to_int(ship.get("hp", 0)) + (3 * delta)
 		ship["hp"] = str(max(hp, 0))
 
 	# при изменении конфигурации слотов может влиять на доступность кнопок
@@ -98,7 +98,7 @@ func _update_buttons() -> void:
 
 			# SPECIAL блок для Farragut
 			var special_arr = ship.get("special", [])
-			var in_special := false
+			var in_special =  false
 			for o in special_arr:
 				if _is_same_template(o):
 					in_special = true
@@ -125,7 +125,7 @@ func _update_buttons() -> void:
 
 			# SPECIAL блок для Farragut
 			var special_arr2 = ship.get("special", [])
-			var in_special2 := false
+			var in_special2 =  false
 			for o in special_arr2:
 				if _is_same_template(o):
 					in_special2 = true
@@ -167,7 +167,7 @@ func _is_same_template(o: Dictionary) -> bool:
 	return o.get("name") == _src.get("name")
 
 func _count_added(ship: Dictionary) -> int:
-	var n := 0
+	var n =  0
 	for o in ship.get("option", []):
 		if _is_same_template(o):
 			n += 1
@@ -184,7 +184,7 @@ func populate(system):
 		_param.text = "[Упорство " + system.get("tenacity") + "] "
 	_param.text += "[Очки " + str(int(system.get("points"))) + "]"
 	_effect.text = system.get("effect")
-	_discription.text = "[i]" + system.get("discription") + "[/i]"
+    _description.text = "[i]" + system.get("discription") + "[/i]"
 	if system.get("feats").size() > 0:
 		var feat1 = system.get("feats").get(0)
 		if feat1.get("type") == Opt.FEAT_TACTIC:
@@ -195,10 +195,10 @@ func populate(system):
 				_range.text = "[Дистанция %s]" % feat1.get("range")
 			_tactic1_effect.text = feat1.get("effect")
 		else:
-			_maneveue1.visible = true
-			_maneveue1_name.text = feat1.get("name")
-			_maneveue1_tag.text = feat1.get("tags")
-			_maneveue1_effect.text = feat1.get("effect")
+                    _maneuver1.visible = true
+                    _maneuver1_name.text = feat1.get("name")
+                    _maneuver1_tag.text = feat1.get("tags")
+                    _maneuver1_effect.text = feat1.get("effect")
 	if system.get("feats").size() > 1:
 		var feat2 = system.get("feats").get(1)
 		if feat2.get("type") == Opt.FEAT_TACTIC:
@@ -207,10 +207,10 @@ func populate(system):
 			_tactic2_tag.text = feat2.get("tags")
 			_tactic2_effect.text = feat2.get("effect")
 		else:
-			_maneveue1.visible = true
-			_maneveue1_name.text = feat2.get("name")
-			_maneveue1_tag.text = feat2.get("tags")
-			_maneveue1_effect.text = feat2.get("effect")
+                    _maneuver1.visible = true
+                    _maneuver1_name.text = feat2.get("name")
+                    _maneuver1_tag.text = feat2.get("tags")
+                    _maneuver1_effect.text = feat2.get("effect")
 
 
 # ───────────────────────────────────────────
@@ -258,7 +258,7 @@ func _on_add_special_pressed() -> void:
 		if _is_same_template(o):
 			return
 
-	var opt := _src.duplicate(true)
+	var opt =  _src.duplicate(true)
 	ship["special"].append(opt)
 
 	# ← эффекты тоже применим (если вдруг эти названия попадут в special)
@@ -287,10 +287,10 @@ func remove_overflow_by_sum() -> bool:
 	if opts.is_empty():
 		return false
 
-	var changed := false
+	var changed =  false
 
 	# Берём суммы (должны содержать "wings" и "escorts")
-	var sums := SlotUtils.get_slot_sums(BattlegroupData.ships[BattlegroupData.current_ship])
+	var sums =  SlotUtils.get_slot_sums(BattlegroupData.ships[BattlegroupData.current_ship])
 
 	# Если крыльев больше лимита → по одному снимаем последние, пока не станет неотрицательно
 	while sums.get("wing") < 0:
@@ -319,7 +319,7 @@ func remove_overflow_by_sum() -> bool:
 # Хелпер: удалить ПОСЛЕДНЮЮ опцию, у которой type совпадает с любым из types_to_match
 func _remove_last_by_types(arr: Array, types_to_match: Array) -> bool:
 	for i in range(arr.size() - 1, -1, -1):
-		var t := int(arr[i].get("type", -999))
+		var t =  int(arr[i].get("type", -999))
 		if t in types_to_match:
 			arr.remove_at(i)
 			return true

--- a/Main_scane/Option_list/system.tscn
+++ b/Main_scane/Option_list/system.tscn
@@ -68,59 +68,59 @@ fit_content = true
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="MarginContainer" parent="VBoxContainer"]
+[node name="Description" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="RichTextLabel" parent="VBoxContainer/Discription"]
+[node name="Description" type="RichTextLabel" parent="VBoxContainer/Description"]
 layout_mode = 2
 mouse_filter = 2
 bbcode_enabled = true
 text = "[i]Большое описание Большое описание Большое описание "
 fit_content = true
 
-[node name="Maneveue1" type="MarginContainer" parent="VBoxContainer"]
+[node name="Maneuver1" type="MarginContainer" parent="VBoxContainer"]
 visible = false
 layout_mode = 2
 mouse_filter = 2
 theme = ExtResource("3_02nco")
 
-[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer/Maneveue1"]
+[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer/Maneuver1"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneveue1/PanelContainer2"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneuver1/PanelContainer2"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 theme = ExtResource("4_fqi33")
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-mouse_filter = 2
-fit_content = true
-
-[node name="Label2" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="Label" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 fit_content = true
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer"]
+[node name="Label2" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+mouse_filter = 2
+fit_content = true
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer/Maneveue1/PanelContainer2/VBoxContainer/MarginContainer"]
+[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer/Maneuver1/PanelContainer2/VBoxContainer/MarginContainer"]
 layout_mode = 2
 mouse_filter = 2
 text = "Описание"

--- a/Main_scane/Option_list/weapon.gd
+++ b/Main_scane/Option_list/weapon.gd
@@ -7,7 +7,7 @@ const Opt = preload("res://option_types.gd")
 @onready var _tags: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Tags
 @onready var _param: RichTextLabel = $VBoxContainer/Head/MarginContainer/VBoxContainer/Param
 @onready var _effect: RichTextLabel = $VBoxContainer/Effect/Effect
-@onready var _discription: RichTextLabel = $VBoxContainer/Discription/Discription
+@onready var _description: RichTextLabel = $VBoxContainer/Description/Description
 @onready var _add: MarginContainer = $VBoxContainer/Button
 @onready var _remove: MarginContainer = $VBoxContainer/Button2
 @onready var _add_special:    MarginContainer = $VBoxContainer/Button3
@@ -43,7 +43,7 @@ func _update_buttons() -> void:
 
 			# ----- SPECIAL UI (только для вспомогательных орудий) -----
 			var special_arr = ship.get("special", [])
-			var in_special := false
+			var in_special =  false
 			for o in special_arr:
 				if _is_same_template(o):
 					in_special = true
@@ -82,7 +82,7 @@ func _update_buttons() -> void:
 
 			# ----- SPECIAL UI (только для вспомогательных орудий) -----
 			var special_arr2 = ship.get("special", [])
-			var in_special2 := false
+			var in_special2 =  false
 			for o in special_arr2:
 				if _is_same_template(o):
 					in_special2 = true
@@ -129,7 +129,7 @@ func _is_same_template(o: Dictionary) -> bool:
 		return o.get("name") == _src.get("name")
 
 func _count_added(ship: Dictionary) -> int:
-		var n := 0
+		var n =  0
 		for o in ship.get("option", []):
 				if _is_same_template(o):
 						n += 1
@@ -157,7 +157,7 @@ func populate(weapon):
 		_param.text += "[Упорство " + weapon.get("tenacity") + "] "
 	_param.text += "[Очки " + str(int(weapon.get("points"))) + "]"
 	_effect.text = weapon.get("effect")
-	_discription.text = "[i]" + weapon.get("discription") + "[/i]"
+_description.text = "[i]" + weapon.get("discription") + "[/i]"
 
 
 func _on_add_pressed() -> void:
@@ -216,7 +216,7 @@ func _on_add_special_pressed() -> void:
 		if _is_same_template(o):
 			return
 
-	var opt := _src.duplicate(true)
+	var opt =  _src.duplicate(true)
 	ship["special"].append(opt)
 
 	# UI обновится через _process/_update_buttons, но подсветим намерение

--- a/Main_scane/Option_list/weapon.tscn
+++ b/Main_scane/Option_list/weapon.tscn
@@ -66,11 +66,11 @@ fit_content = true
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="MarginContainer" parent="VBoxContainer"]
+[node name="Description" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="RichTextLabel" parent="VBoxContainer/Discription"]
+[node name="Description" type="RichTextLabel" parent="VBoxContainer/Description"]
 layout_mode = 2
 mouse_filter = 2
 bbcode_enabled = true

--- a/Main_scane/control.gd
+++ b/Main_scane/control.gd
@@ -4,8 +4,8 @@ class_name PWAInstaller
 @export var install_button_path: NodePath = NodePath()
 var _install_button: Button
 
-var _poll_timer := 0.0
-var _ios_hint_shown := false
+var _poll_timer = 0.0
+var _ios_hint_shown = false
 
 func _ready() -> void:
 	if !OS.has_feature("web"):
@@ -69,7 +69,7 @@ func _process(delta: float) -> void:
 		_poll_timer = 0.0
 		_update_button_visibility()
 
-func _update_button_visibility(force := false) -> void:
+func _update_button_visibility(force = false) -> void:
 	if !_install_button:
 		return
 
@@ -132,7 +132,7 @@ func _show_generic_help() -> void:
 	_show_toast("Нужно: HTTPS, валидный webmanifest, Service Worker и иконки. Тогда появится кнопка установки.")
 
 func _show_toast(msg: String, seconds: float = 4.0) -> void:
-	var label := Label.new()
+	var label = Label.new()
 	label.text = msg
 	label.autowrap_mode = TextServer.AUTOWRAP_WORD
 	label.theme_type_variation = "HeaderSmall"
@@ -141,7 +141,7 @@ func _show_toast(msg: String, seconds: float = 4.0) -> void:
 	label.add_theme_constant_override("outline_size", 2)
 
 	# фон
-	var panel := PanelContainer.new()
+	var panel = PanelContainer.new()
 	panel.add_theme_stylebox_override("panel", _toast_stylebox())
 	panel.add_child(label)
 
@@ -154,7 +154,7 @@ func _show_toast(msg: String, seconds: float = 4.0) -> void:
 	panel.offset_bottom = -24
 	panel.offset_top = -96
 
-	var parent := get_tree().current_scene if get_tree().current_scene else self
+	var parent = get_tree().current_scene if get_tree().current_scene else self
 	parent.add_child(panel)
 	panel.top_level = true
 
@@ -162,7 +162,7 @@ func _show_toast(msg: String, seconds: float = 4.0) -> void:
 	panel.queue_free()
 
 func _toast_stylebox() -> StyleBoxFlat:
-	var sb := StyleBoxFlat.new()
+	var sb = StyleBoxFlat.new()
 	sb.bg_color = Color(0,0,0,0.8)
 	sb.corner_radius_top_left = 12
 	sb.corner_radius_top_right = 12

--- a/Main_scane/main.gd
+++ b/Main_scane/main.gd
@@ -39,7 +39,7 @@ func change_on_main():
 func _on_hull_list_change_scene() -> void:
 	_toggle_sections(true, false)
 	print(BattlegroupData.ships, "\n\n")
-	print(BattlegroupData.comander)
+        print(BattlegroupData.commander)
 
 
 func _on_commander_change_scene(parent_node: Node) -> void:
@@ -48,7 +48,7 @@ func _on_commander_change_scene(parent_node: Node) -> void:
 	_toggle_sections(false, true)
 	
 
-func _toggle_sections(show_hull_list := false, show_note := false) -> void:
+func _toggle_sections(show_hull_list = false, show_note = false) -> void:
 	main.visible      = not (show_hull_list or show_note)
 	hull_list.visible = show_hull_list
 	note.visible      = show_note

--- a/battlegroup_data.gd
+++ b/battlegroup_data.gd
@@ -10,14 +10,14 @@ var point = 0
 const SAVE_PATH = "user://battlegroup_save.json"
 
 # 1️⃣ максимумы
-const MAX_COUNTS := {
+const MAX_COUNTS = {
 	ShipClass.FRIGATE:    3,
 	ShipClass.CARRIER:    2,
 	ShipClass.BATTLESHIP: 1,
 }
 
 # 2️⃣ текущее количество взятых корпусов
-var class_counts := {
+var class_counts = {
 	ShipClass.FRIGATE:    0,
 	ShipClass.CARRIER:    0,
 	ShipClass.BATTLESHIP: 0,
@@ -27,7 +27,7 @@ var current_ship = -1
 
 var ships: Array = []
 
-var comander: Dictionary = {
+var commander: Dictionary = {
 	"name": "",
 	"positive_1": "",
 	"positive_2": "",
@@ -43,20 +43,20 @@ var comander: Dictionary = {
 
 # Добавление.  ➜ true — успех, false — отказ (лимит/неизвестный класс/уже есть).
 func add_hull(hull: Dictionary) -> bool:
-	var cls := int(hull.get("class", -1))
+        var cls = int(hull.get("class", -1))
 	if class_counts[cls] >= MAX_COUNTS[cls] or point + int(hull.get("points")) > 20:
 		return false
 
 	# 🔑 создаём глубокую копию, чтобы объект был уникален
-	var new_hull := hull.duplicate(true)   # true → deep copy
+        var new_hull = hull.duplicate(true)   # true → deep copy
 
 	# 1. находим первый свободный номер
-	var used := {}
+        var used = {}
 	for s in ships:
-		var parts := str(s.get("ship_name", "")).split(" ")
+                var parts = str(s.get("ship_name", "")).split(" ")
 		if parts.size() == 2 and parts[0] == "Имя":
 			used[int(parts[1])] = true
-	var idx := 1
+        var idx = 1
 	while used.has(idx):
 		idx += 1
 
@@ -77,7 +77,7 @@ func add_hull(hull: Dictionary) -> bool:
 # Удаление.  ➜ true — удалил, false — не нашёл.
 func remove_hull(hull: Dictionary) -> bool:
 	var target_name = hull.get("name", "")
-	var idx := -1
+        var idx = -1
 
 	# идём с конца в начало
 	for i in range(ships.size() - 1, -1, -1):
@@ -89,7 +89,7 @@ func remove_hull(hull: Dictionary) -> bool:
 		return false        # корпус с таким name не найден
 
 	# определяем класс удаляемого корпуса, чтобы корректно уменьшить счётчики
-	var cls := int(ships[idx].get("class", -1))
+        var cls = int(ships[idx].get("class", -1))
 
 	ships.remove_at(idx)
 	class_counts[cls] = max(class_counts[cls] - 1, 0)
@@ -109,7 +109,7 @@ func can_add(cls: int) -> bool:
 func refresh_point():
 	point = 0
 	for ship in ships:
-		var total := int(ship.get("points", 0))
+                var total = int(ship.get("points", 0))
 		var spec = 0
 		for opt in ship.get("option", []):
 			if ship.get("class") == 1.0 and (opt.get("type") == 5.0 or opt.get("type") == 4.0):
@@ -140,12 +140,12 @@ func refresh_point():
 		point += total + spec
 
 func will_exceed_20(opt: Dictionary) -> bool:
-	var total_points := 0
+        var total_points = 0
 	
 	for i in range(ships.size()):
 		var ship = ships[i]
-		var ship_total := 0
-		var spec := 0
+                var ship_total = 0
+                var spec = 0
 		
 		# Собираем список опций для подсчёта.
 		# Для целевого корабля добавляем "виртуально" новую опцию.
@@ -155,11 +155,11 @@ func will_exceed_20(opt: Dictionary) -> bool:
 		
 		# Подсчёт очков по правилам
 		for o in opts:
-			var o_points := int(o.get("points", 0))
-			var o_mod_points := int(o.get("modification", {}).get("point", 0))
-			var o_type = o.get("type")
-			var s_class = ship.get("class")
-			var s_name := String(ship.get("name", ""))
+                        var o_points = int(o.get("points", 0))
+                        var o_mod_points = int(o.get("modification", {}).get("point", 0))
+                        var o_type = o.get("type")
+                        var s_class = ship.get("class")
+                        var s_name = String(ship.get("name", ""))
 			
 			if s_class == 1.0 and (o_type == 5.0 or o_type == 4.0):
 				spec += o_points
@@ -199,10 +199,10 @@ func _enter_tree() -> void:
 	load_data()
 
 func save_data() -> void:
-	var data = {
-		"ships": ships,
-		"comander": comander
-	}
+        var data = {
+                "ships": ships,
+                "commander": commander
+        }
 	var file = FileAccess.open(SAVE_PATH, FileAccess.WRITE)
 	if file:
 		file.store_string(JSON.stringify(data))
@@ -216,8 +216,8 @@ func load_data() -> void:
 			file.close()
 			var result = JSON.parse_string(text)
 			if typeof(result) == TYPE_DICTIONARY:
-				ships = result.get("ships", [])
-				comander = result.get("comander", comander)
+                                ships = result.get("ships", [])
+                                commander = result.get("commander", commander)
 				class_counts[ShipClass.FRIGATE] = 0
 				class_counts[ShipClass.CARRIER] = 0
 				class_counts[ShipClass.BATTLESHIP] = 0

--- a/note.gd
+++ b/note.gd
@@ -19,5 +19,5 @@ func _on_visibility_changed() -> void:
 
 
 func _on_text_edit_text_changed() -> void:
-	BattlegroupData.comander["backstory"] = $TextEdit.text
+        BattlegroupData.commander["backstory"] = $TextEdit.text
 	BattlegroupData.save_data()

--- a/options.gd
+++ b/options.gd
@@ -2,7 +2,7 @@ extends GridContainer
 
 const SlotUtils = preload("res://slot_utils.gd")
 
-@onready var _labels := {
+@onready var _labels = {
 	"point":$Points/Point,
 	"superheavy": $Superheavies/Superheavy,
 	"primaries": $Primaries/Primary,
@@ -19,7 +19,7 @@ func _process(delta: float) -> void:
 
 
 func _update_from_ship() -> void:
-		var idx := int(BattlegroupData.current_ship)
+                var idx = int(BattlegroupData.current_ship)
 		if idx < 0 or idx >= BattlegroupData.ships.size():
 				return
 		var ship = BattlegroupData.ships[idx]
@@ -39,7 +39,7 @@ func _update_from_ship() -> void:
 		_refresh_visibility()
 
 func _refresh_visibility() -> void:
-	var any_visible := false
+        var any_visible = false
 	for c in get_children():
 		if c.get_child(1).text != "0/0":
 			c.visible = true

--- a/support_scanes/Feat.tscn
+++ b/support_scanes/Feat.tscn
@@ -85,7 +85,7 @@ wrap_mode = 1
 scroll_fit_content_height = true
 use_default_word_separators = false
 
-[node name="Feat_discription_text_edit" type="TextEdit" parent="."]
+[node name="Feat_description_text_edit" type="TextEdit" parent="."]
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 placeholder_text = "Описание"

--- a/support_scanes/hull.gd
+++ b/support_scanes/hull.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 #signal hull_added(hull_data)     # чтобы подписаться извне
 #signal hull_removed(hull_data)     # чтобы подписаться извне
 
-const FEAT_SCENE := preload("res://Main_scane/Hull_list/Feat_for_showing.tscn")
+const FEAT_SCENE = preload("res://Main_scane/Hull_list/Feat_for_showing.tscn")
 
 # --- ссылки на виджеты ---------------------------------------------------
 @onready var _name        : Label          = $Name
@@ -21,7 +21,7 @@ const FEAT_SCENE := preload("res://Main_scane/Hull_list/Feat_for_showing.tscn")
 @onready var _escort      : Label          = $Options/Escorts/Escort
 @onready var _system      : Label          = $Options/Systems/System
 @onready var _feat_box    : VBoxContainer  = $MarginContainer/Feats_container
-@onready var _discription : RichTextLabel  = $MarginContainer2/Discription
+@onready var _description : RichTextLabel  = $MarginContainer2/Description
 @onready var _add_btn     : Button         = $Button
 @onready var _remove_btn  : Button         = $Button2
 
@@ -52,7 +52,7 @@ func populate(data: Dictionary) -> void:
 	_wing.text       = str(data.get("support_slots").get("wings"))
 	_escort.text     = str(data.get("support_slots").get("escorts"))
 	_system.text     = str(data.get("support_slots").get("systems"))
-	_discription.text= str(data.get("discription"))
+        _description.text = str(data.get("discription"))
 	# описание и черта (feats[0])
 	for x in data.get("feats"):
 		_spawn_feat(x)
@@ -70,8 +70,8 @@ func _connect_buttons() -> void:
 # 👉 Единое место, которое решает «показать/спрятать»
 func _update_buttons() -> void:
 	var cls: int = _src["class"]
-	var already_added := _count_added()
-	var reached_limit := not BattlegroupData.can_add(cls)
+        var already_added = _count_added()
+        var reached_limit = not BattlegroupData.can_add(cls)
 
 	_remove_btn.visible = already_added > 0
 	_add_btn.visible    = not reached_limit \
@@ -92,7 +92,7 @@ func _on_remove_pressed() -> void:
 
 
 func _spawn_feat(feat_data) -> void:
-	var feat := FEAT_SCENE.instantiate()
+        var feat = FEAT_SCENE.instantiate()
 	_feat_box.add_child(feat)
 	feat.populate(feat_data)
 
@@ -101,7 +101,7 @@ func _is_same_template(h: Dictionary) -> bool:
 	return h.get("name") == _src.get("name")
 
 func _count_added() -> int:
-	var n := 0
+        var n = 0
 	for s in BattlegroupData.ships:
 		if _is_same_template(s):
 			n += 1

--- a/support_scanes/hull.tscn
+++ b/support_scanes/hull.tscn
@@ -220,7 +220,7 @@ mouse_filter = 2
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Discription" type="RichTextLabel" parent="Hull/MarginContainer2"]
+[node name="Description" type="RichTextLabel" parent="Hull/MarginContainer2"]
 layout_mode = 2
 mouse_filter = 2
 fit_content = true

--- a/support_scanes/options.gd
+++ b/support_scanes/options.gd
@@ -14,7 +14,7 @@ func _process(delta: float) -> void:
 # Вызывай этот метод, когда цифры в Label-ах меняются,
 # например из другого скрипта или после загрузки данных.
 func refresh_visibility() -> void:
-	var any_container_visible := false
+        var any_container_visible = false
 
 	for container in get_children():
 		# Проверяем, что это действительно контейнер с дочерними узлами.
@@ -36,8 +36,8 @@ func refresh_visibility() -> void:
 			any_container_visible = true
 			continue
 
-		var number := int(label_to_check.text.strip_edges())
-		var show := number != 0
+                var number = int(label_to_check.text.strip_edges())
+                var show = number != 0
 		container.visible = show
 
 		if show:


### PR DESCRIPTION
## Summary
- replace all `:=` typed assignments with standard `=` across scripts
- correct misspelled variables and nodes (e.g. commander, description, maneuver)
- standardize UI references and helper utilities

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8689563908320a81a486bc0b83091